### PR TITLE
Add local database infrastructure using Docker-Compose

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,5 @@
 import BuildHelper._
+import InfrastructureHelper._
 
 inThisBuild(
   List(
@@ -12,6 +13,24 @@ inThisBuild(
 
 addCommandAlias("fmt", "all scalafmtSbt scalafmt test:scalafmt")
 addCommandAlias("check", "all scalafmtSbtCheck scalafmtCheck test:scalafmtCheck")
+
+lazy val startPostgres = taskKey[Unit]("Start up Postgres")
+startPostgres := startService(Database.Postgres, streams.value)
+
+lazy val stopPostgres = taskKey[Unit]("Shut down Postgres")
+stopPostgres := stopService(Database.Postgres, streams.value)
+
+lazy val startMySQL = taskKey[Unit]("Start up MySQL")
+startMySQL := startService(Database.MySQL, streams.value)
+
+lazy val stopMySQL = taskKey[Unit]("Shut down MySQL")
+stopMySQL := stopService(Database.MySQL, streams.value)
+
+lazy val startOracle = taskKey[Unit]("Start up Oracle")
+startOracle := startService(Database.Oracle, streams.value)
+
+lazy val stopOracle = taskKey[Unit]("Shut down Oracle")
+stopOracle := stopService(Database.Oracle, streams.value)
 
 lazy val root = project
   .in(file("."))

--- a/build.sbt
+++ b/build.sbt
@@ -26,6 +26,12 @@ startMySQL := startService(Database.MySQL, streams.value)
 lazy val stopMySQL = taskKey[Unit]("Shut down MySQL")
 stopMySQL := stopService(Database.MySQL, streams.value)
 
+lazy val startMsSQL = taskKey[Unit]("Start up Microsoft SQL Server")
+startMsSQL := startService(Database.MSSQL, streams.value)
+
+lazy val stopMsSQL = taskKey[Unit]("Shut down Microsoft SQL Server")
+stopMsSQL := stopService(Database.MSSQL, streams.value)
+
 lazy val startOracle = taskKey[Unit]("Start up Oracle")
 startOracle := startService(Database.Oracle, streams.value)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,33 @@
+version: '3.1'
+
+services:
+  postgres:
+    image: postgres:12
+    restart: always
+    environment:
+      POSTGRES_USER: zio_user
+      POSTGRES_PASSWORD: zio_pw
+    ports:
+      - "5432:5432"
+
+  mysql:
+    image: mysql:8
+    restart: always
+    environment:
+      MYSQL_USER: zio_user
+      MYSQL_PASSWORD: zio_pw
+      MYSQL_ROOT_PASSWORD: zio_pw
+    ports:
+      - "3306:3306"
+
+  oracle:
+    image: oracleinanutshell/oracle-xe-11g
+    restart: always
+    environment:
+      ORACLE_ALLOW_REMOTE: 'true'
+      ORACLE_DISABLE_ASYNCH_IO: 'true'
+    ports:
+      - "1521:1521"
+      - "5500:5500"
+    # Username: system
+    # Password: oracle

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,17 @@ services:
     ports:
       - "3306:3306"
 
+  mssql:
+    image: mcr.microsoft.com/mssql/server:2019-latest
+    restart: always
+    environment:
+      ACCEPT_EULA: Y
+      SA_PASSWORD: zio_pw123ABC!
+      MSSQL_PID: Developer
+    ports:
+    - "1433:1433"
+      # Username: sa
+
   oracle:
     image: oracleinanutshell/oracle-xe-11g
     restart: always
@@ -29,5 +40,6 @@ services:
     ports:
       - "1521:1521"
       - "5500:5500"
+    # SID: XE
     # Username: system
     # Password: oracle

--- a/project/InfrastructureHelper.scala
+++ b/project/InfrastructureHelper.scala
@@ -10,12 +10,14 @@ object InfrastructureHelper {
     def name: String = self match {
       case Database.Postgres => "postgres"
       case Database.MySQL    => "mysql"
+      case Database.MSSQL    => "mssql"
       case Database.Oracle   => "oracle"
     }
 
     def port: Int = self match {
       case Database.Postgres => 5432
       case Database.MySQL    => 3306
+      case Database.MSSQL    => 1433
       case Database.Oracle   => 1521
     }
   }
@@ -23,6 +25,7 @@ object InfrastructureHelper {
   object Database {
     case object Postgres extends Database
     case object MySQL    extends Database
+    case object MSSQL    extends Database
     case object Oracle   extends Database
   }
 

--- a/project/InfrastructureHelper.scala
+++ b/project/InfrastructureHelper.scala
@@ -1,0 +1,44 @@
+import sbt.Keys.TaskStreams
+
+import scala.sys.process._
+
+object InfrastructureHelper {
+
+  sealed trait Database { self =>
+
+    // must align with the service name in docker-compose.yaml
+    def name: String = self match {
+      case Database.Postgres => "postgres"
+      case Database.MySQL    => "mysql"
+      case Database.Oracle   => "oracle"
+    }
+
+    def port: Int = self match {
+      case Database.Postgres => 5432
+      case Database.MySQL    => 3306
+      case Database.Oracle   => 1521
+    }
+  }
+
+  object Database {
+    case object Postgres extends Database
+    case object MySQL    extends Database
+    case object Oracle   extends Database
+  }
+
+  val shell: Seq[String] =
+    if (sys.props("os.name").contains("Windows")) Vector("cmd", "/c")
+    else Vector("bash", "-c")
+
+  def startService(db: Database, s: TaskStreams): Unit = {
+    val dockerComposeUp = shell :+ s"docker-compose up -d ${db.name}"
+    if (dockerComposeUp.! == 0) s.log.success(s"${db.name} started on port ${db.port}")
+    else s.log.error("Postgres was not able to start up")
+  }
+
+  def stopService(db: Database, s: TaskStreams): Unit = {
+    val dockerComposeDown = shell :+ s"docker-compose stop ${db.name}"
+    if (dockerComposeDown.! == 0) s.log.success(s"${db.name} was stopped")
+    else s.log.error(s"${db.name} was not able to shut down properly")
+  }
+}


### PR DESCRIPTION
Adds the following SBT commands: 
- `startPostgres`
- `stopPostgres`
- `startMySQL`
- `stopMySQL`
- `startMsSQL`
- `stopMsSQL`
- `startOracle`
- `stopOracle`

These commands make calls to Docker-Compose to start up and shutdown the appropriate database

Tackles #18, #19,  #20, #21 

