### PR TITLE
Make Expr Covariant on Output Type

### DIFF
--- a/project/BuildHelper.scala
+++ b/project/BuildHelper.scala
@@ -106,11 +106,9 @@ object BuildHelper {
     }
 
   def platformSpecificSources(platform: String, conf: String, baseDirectory: File)(versions: String*) =
-    List("scala" :: versions.toList.map("scala-" + _): _*)
-      .map { version =>
-        baseDirectory.getParentFile / platform.toLowerCase / "src" / conf / version
-      }
-      .filter(_.exists)
+    List("scala" :: versions.toList.map("scala-" + _): _*).map { version =>
+      baseDirectory.getParentFile / platform.toLowerCase / "src" / conf / version
+    }.filter(_.exists)
 
   def crossPlatformSources(scalaVer: String, platform: String, conf: String, baseDir: File, isDotty: Boolean) =
     CrossVersion.partialVersion(scalaVer) match {

--- a/zio-sql/jvm/src/main/scala/Sql.scala
+++ b/zio-sql/jvm/src/main/scala/Sql.scala
@@ -583,9 +583,9 @@ trait Sql {
     }
   }
 
-  sealed case class AggregationDef[-A, B](name: FunctionName) { self =>
+  sealed case class AggregationDef[-A, +B](name: FunctionName) { self =>
 
-    def apply[F, Source, A1 <: A](expr: Expr[F, Source, A1]): Expr[Features.Aggregated[F], Source, B] =
+    def apply[F, Source](expr: Expr[F, Source, A]): Expr[Features.Aggregated[F], Source, B] =
       Expr.AggregationCall(expr, self)
   }
 

--- a/zio-sql/jvm/src/main/scala/Sql.scala
+++ b/zio-sql/jvm/src/main/scala/Sql.scala
@@ -248,12 +248,14 @@ trait Sql {
 
     def lhs: Expr[F, A, Value]
     def rhs: Expr[_, A, Value]
+
+    def typeTag: TypeTag[Value]
   }
 
   object Set {
     type Aux[F, -A, Value0] = Set[F, A] { type Value = Value0 }
 
-    def apply[F: Features.IsSource, A, Value0](
+    def apply[F: Features.IsSource, A, Value0: TypeTag](
       lhs0: Expr[F, A, Value0],
       rhs0: Expr[_, A, Value0]
     ): Set.Aux[F, A, Value0] =
@@ -262,6 +264,8 @@ trait Sql {
 
         def lhs = lhs0
         def rhs = rhs0
+
+        def typeTag = implicitly[TypeTag[Value]]
       }
   }
 


### PR DESCRIPTION
By moving `as` and `in` to implicit syntax we can recover covariance on output types of `Expr` and `FunctionDef`.