### PR TITLE
Add mathematical functions

### DIFF
--- a/zio-sql/jvm/src/main/scala/Sql.scala
+++ b/zio-sql/jvm/src/main/scala/Sql.scala
@@ -627,16 +627,24 @@ trait Sql {
   }
 
   object FunctionDef {
-    //match functions
+    //math functions
     val Abs   = FunctionDef[Double, Double](FunctionName("abs"))
+    val Acos  = FunctionDef[Double, Double](FunctionName("acos"))
+    val Asin  = FunctionDef[Double, Double](FunctionName("asin"))
+    val Atan  = FunctionDef[Double, Double](FunctionName("atan"))
     val Ceil  = FunctionDef[Double, Double](FunctionName("ceil"))
+    val Cos   = FunctionDef[Double, Double](FunctionName("cos"))
     val Exp   = FunctionDef[Double, Double](FunctionName("exp"))
     val Floor = FunctionDef[Double, Double](FunctionName("floor"))
     //val Log = FunctionDef[Double, Double](FunctionName("log")) //not part of SQL 2011 spec
     val Ln          = FunctionDef[Double, Double](FunctionName("ln"))
     val Mod         = FunctionDef[(Double, Double), Double](FunctionName("mod"))
     val Power       = FunctionDef[(Double, Double), Double](FunctionName("power"))
+    val Round       = FunctionDef[(Double, Int), Double](FunctionName("round"))
+    val Sign        = FunctionDef[Double, Double](FunctionName("sign"))
+    val Sin         = FunctionDef[Double, Double](FunctionName("sin"))
     val Sqrt        = FunctionDef[Double, Double](FunctionName("sqrt"))
+    val Tan         = FunctionDef[Double, Double](FunctionName("tan"))
     val WidthBucket = FunctionDef[(Double, Double, Double, Int), Int](FunctionName("width bucket"))
 
     //string functions


### PR DESCRIPTION
Based on the following docs:
- https://dev.mysql.com/doc/refman/8.0/en/mathematical-functions.html
- https://www.postgresql.org/docs/12/functions-math.html
- https://docs.microsoft.com/en-us/sql/t-sql/functions/mathematical-functions-transact-sql?view=sql-server-ver15
- https://docs.oracle.com/database/121/SQLRF/functions002.htm#SQLRF51178

mathematical functions supported by all 4 servers (mysql, postgresql, sql sever and oracle) are:
- ABS()	  
- ACOS()	  
- ASIN()	  
- ATAN()	  
- COS()	  
- EXP()	  
- POWER()	  
- ROUND()	  
- SIGN()	  
- SIN()	  
- SQRT()	  
- TAN()	

There is also  `ATAN2()` but for SQL Server the name of this function is  `ATN2`.
A similar situation is for `TRUNCATE` function. Its name for Mysql is `TRUNCATE`, for Postgresql and Oracle it is `trunc` but for SQL Server you have to use `ROUND(_ , _, 1)` function with the third parameter different than `0`.

The other problem I see is that even if the function is supported for all 4 servers it can have different parameters e.g. `ROUND`:
- for Mysql `ROUND(X,D)` - ` D defaults to 0 if not specified` so `D` is optional
- for Postgresql and Oracle second argument of `ROUND` is also optional
- SQL Server `ROUND ( numeric_expression , length [ ,function ] )` has three input arguments second argument is required, third argument is optional


