### PR TITLE
Add string functions

### DIFF
--- a/zio-sql/jvm/src/main/scala/Sql.scala
+++ b/zio-sql/jvm/src/main/scala/Sql.scala
@@ -651,11 +651,16 @@ trait Sql {
     val WidthBucket = FunctionDef[(Double, Double, Double, Int), Int](FunctionName("width bucket"))
 
     //string functions
+    val Ascii       = FunctionDef[String, Int](FunctionName("ascii"))
     val CharLength  = FunctionDef[String, Int](FunctionName("character length"))
+    val Concat      = FunctionDef[(String, String), String](FunctionName("concat"))
     val Lower       = FunctionDef[String, String](FunctionName("lower"))
+    val Ltrim       = FunctionDef[String, String](FunctionName("ltrim"))
     val OctetLength = FunctionDef[String, Int](FunctionName("octet length"))
     val Overlay     = FunctionDef[(String, String, Int, Option[Int]), String](FunctionName("overlay"))
     val Position    = FunctionDef[(String, String), Int](FunctionName("position"))
+    val Replace     = FunctionDef[(String, String), String](FunctionName("replace"))
+    val Rtrim       = FunctionDef[String, String](FunctionName("rtrim"))
     val Substring   = FunctionDef[(String, Int, Option[Int]), String](FunctionName("substring"))
     //TODO substring regex
     val Trim  = FunctionDef[String, String](FunctionName("trim"))


### PR DESCRIPTION
For #5 

Based on the following docs:
- https://dev.mysql.com/doc/refman/8.0/en/string-functions.html
- https://www.postgresql.org/docs/12/functions-string.html
- https://docs.microsoft.com/en-us/sql/t-sql/functions/string-functions-transact-sql?view=sql-server-ver15
- https://docs.oracle.com/database/121/SQLRF/functions002.htm#SQLRF51178

string functions supported by all 4 servers (mysql, postgresql, sql sever and oracle) are:
- `ASCII`	 
- `CONCAT`	 
- `LOWER`	 
- `LTRIM`	 
- `REPLACE`  
- `RTRIM`	 
- `TRIM`	 
- `UPPER`  