### PR TITLE
Support selecting columns using existing column names

### DIFF
--- a/zio-sql/jvm/src/main/scala/Sql.scala
+++ b/zio-sql/jvm/src/main/scala/Sql.scala
@@ -461,15 +461,6 @@ trait Sql {
 
   type :||:[A, B] = Features.Union[A, B]
 
-  def exprName[F, A, B](expr: Expr[F, A, B]): Option[String] =
-    expr match {
-      case Expr.Source(_, c) => Some(c.name)
-      case _ => None
-    }
-
-  implicit def expToSelection[F, A, B](expr: Expr[F, A, B]): Selection[F, A, SelectionSet.Cons[A, B, SelectionSet.Empty]] =
-    Selection.computedOption(expr, exprName(expr))
-
   /**
    * Models a function `A => B`.
    * SELECT product.price + 10
@@ -555,6 +546,15 @@ trait Sql {
 
   object Expr {
     implicit def literal[A: TypeTag](a: A): Expr[Features.Literal, Any, A] = Expr.Literal(a)
+
+    def exprName[F, A, B](expr: Expr[F, A, B]): Option[String] =
+      expr match {
+        case Expr.Source(_, c) => Some(c.name)
+        case _ => None
+      }
+
+    implicit def expToSelection[F, A, B](expr: Expr[F, A, B]): Selection[F, A, SelectionSet.Cons[A, B, SelectionSet.Empty]] =
+      Selection.computedOption(expr, exprName(expr))
 
     sealed case class Source[A, B] private[Sql] (tableName: TableName, column: Column[B])
         extends Expr[Features.Source, A, B]

--- a/zio-sql/jvm/src/main/scala/Sql.scala
+++ b/zio-sql/jvm/src/main/scala/Sql.scala
@@ -461,6 +461,15 @@ trait Sql {
 
   type :||:[A, B] = Features.Union[A, B]
 
+  def exprName[F, A, B](expr: Expr[F, A, B]): Option[String] =
+    expr match {
+      case Expr.Source(_, c) => Some(c.name)
+      case _ => None
+    }
+
+  implicit def expToSelection[F, A, B](expr: Expr[F, A, B]) =
+    Selection.computedOption(expr, exprName(expr))
+
   /**
    * Models a function `A => B`.
    * SELECT product.price + 10

--- a/zio-sql/jvm/src/main/scala/Sql.scala
+++ b/zio-sql/jvm/src/main/scala/Sql.scala
@@ -467,7 +467,7 @@ trait Sql {
       case _ => None
     }
 
-  implicit def expToSelection[F, A, B](expr: Expr[F, A, B]) =
+  implicit def expToSelection[F, A, B](expr: Expr[F, A, B]): Selection[F, A, SelectionSet.Cons[A, B, SelectionSet.Empty]] =
     Selection.computedOption(expr, exprName(expr))
 
   /**

--- a/zio-sql/jvm/src/test/scala/TestBasicSelectSpec.scala
+++ b/zio-sql/jvm/src/test/scala/TestBasicSelectSpec.scala
@@ -1,0 +1,32 @@
+package zio.sql
+
+import zio.test._
+import zio.test.Assertion._
+
+object TestBasicSelect {
+  val userSql = new Sql { self =>
+    import self.ColumnSet._
+
+    val userTable = (string("user_id") ++ localDate("dob") ++ string("first_name") ++ string("last_name")).table("users")
+
+    val userId :*: dob :*: fName :*: lName :*: _ = userTable.columns
+
+    //todo this should compile using column names defined in the table
+    val basicSelect = select { fName ++ lName } from userTable
+
+    // fName and lName already have column names, shouldn't have to do this
+    val basicSelectWithAliases = (select {
+      (fName as "first_name") ++ (lName as "last_name")
+    } from userTable)
+  }
+}
+
+object TestBasicSelectSpec extends DefaultRunnableSpec {
+  import TestBasicSelect.userSql._
+
+  def spec = suite("TestBasicSelectSpec")(
+    test("Selecting columns using existing column names") {
+      assert(basicSelect)(equalTo(basicSelectWithAliases))
+    }
+  )
+}


### PR DESCRIPTION
Implicit conversion from Expr[F, A, B] to Selection[F, A, SelectionSet.Cons[A, B, SelectionSet.Empty]]
to support select with default column names:

```scala
val userId :*: dob :*: fName :*: lName :*: _ = userTable.columns

val basicSelect = select { fName ++ lName } from userTable
```

Would it be possible to modify exprName to allow select arbitrary expressions with an auto generated name ?
```scala
  def exprName[F, A, B](expr: Expr[F, A, B]): Option[String] =
    expr match {
      case Expr.Source(_, c) => Some(c.name)
      case _ => None
    }
```