### PR TITLE
Add current_timestamp function

### DIFF
--- a/zio-sql/jvm/src/main/scala/Sql.scala
+++ b/zio-sql/jvm/src/main/scala/Sql.scala
@@ -665,6 +665,9 @@ trait Sql {
     //TODO substring regex
     val Trim  = FunctionDef[String, String](FunctionName("trim"))
     val Upper = FunctionDef[String, String](FunctionName("upper"))
+
+    // date functions
+    val CurrentTimestamp = FunctionDef[Nothing, Instant](FunctionName("current_timestamp"))
   }
 
   object Example1 {


### PR DESCRIPTION
There are many date&time functions but only `CURRENT_TIMESTAMP()` is supported by Postgres, MySQL, SQL Server and Oracle.

- https://dev.mysql.com/doc/refman/8.0/en/date-and-time-functions.html
- https://www.postgresql.org/docs/12/functions-datetime.html
- https://docs.microsoft.com/en-us/sql/t-sql/functions/date-and-time-data-types-and-functions-transact-sql?view=sql-server-ver15
- https://docs.oracle.com/database/121/SQLRF/functions002.htm#SQLRF51180

For #5 