### PR TITLE
Force delete from source

### DIFF
--- a/zio-sql/jvm/src/main/scala/Sql.scala
+++ b/zio-sql/jvm/src/main/scala/Sql.scala
@@ -173,6 +173,8 @@ trait Sql {
 
     final def rightOuter[That](that: Table.Aux[That]): Table.JoinBuilder[self.TableType, That] =
       new Table.JoinBuilder[self.TableType, That](JoinType.RightOuter, self, that)
+
+    private[Sql] def widen: Table.Aux[TableType] = self.asInstanceOf[Table.Aux[TableType]]
   }
 
   object Table {
@@ -231,12 +233,12 @@ trait Sql {
   }
 
   sealed case class DeleteBuilder[F[_], A, B](table: Table.Source.Aux[F, A, B]) {
-    def where[F1](expr: Expr[F1, B, Boolean]): Delete[F1, F, A, B] = Delete(table, expr)
+    def where[F1](expr: Expr[F1, B, Boolean]): Delete[F1, B] = Delete(table.widen, expr)
   }
 
-  sealed case class Delete[F1, F[_], A, B](
-    table: Table.Source.Aux[F, A, B],
-    whereExpr: Expr[F1, B, Boolean]
+  sealed case class Delete[F, A](
+    table: Table.Aux[A],
+    whereExpr: Expr[F, A, Boolean]
   )
 
   // UPDATE table

--- a/zio-sql/jvm/src/main/scala/zio/sql/Examples.scala
+++ b/zio-sql/jvm/src/main/scala/zio/sql/Examples.scala
@@ -33,11 +33,6 @@ object Examples {
   //delete from users where first_name = 'Terrence'
   val basicDelete = deleteFrom(users).where(fName === "Terrence")
 
-  //NOT VALID todo fix issue #37
-  //Incorrect syntax near the keyword 'inner'.
-  //delete from orders inner join users on orders.usr_id = users.usr_id where first_name = 'Terrence'
-  val invalidJoinDelete = deleteFrom((orders join users).on(fkUserId === userId)).where(fName === "Terrence")
-
   /*
     val deleteFromWithSubquery = deleteFrom(orders).where(fkUserId in {
       select(userId as "id") from users where (fName === "Fred") //todo fix issue #36

--- a/zio-sql/jvm/src/main/scala/zio/sql/Examples.scala
+++ b/zio-sql/jvm/src/main/scala/zio/sql/Examples.scala
@@ -33,11 +33,6 @@ object Examples {
   //delete from users where first_name = 'Terrence'
   val basicDelete = deleteFrom(users).where(fName === "Terrence")
 
-  //NOT VALID todo fix issue #37
-  //Incorrect syntax near the keyword 'inner'.
-  //delete from orders inner join users on orders.usr_id = users.usr_id where first_name = 'Terrence'
-  val invalidJoinDelete = deleteFrom((orders join users).on(fkUserId === userId)).where(fName === "Terrence")
-
   /*
     val deleteFromWithSubquery = deleteFrom(orders).where(fkUserId in {
       select(userId as "id") from users where (fName === "Fred") //todo fix issue #36
@@ -59,7 +54,7 @@ object Examples {
     (Arbitrary(userId) as "usr_id") ++
       (Arbitrary(fName) as "first_name") ++
       (Arbitrary(lName) as "last_name") ++
-      (Arbitrary(orderId) as "order_id") ++ //todo fix #39, remove column 
+      (Arbitrary(orderId) as "order_id") ++ //todo fix #39, remove column
       (Sum(quantity * unitPrice) as "total_spend")
   }
     from {
@@ -69,7 +64,7 @@ object Examples {
         .leftOuter(orderDetails)
         .on(orderId == fkOrderId)
     })
-    .groupBy(userId, fName /*, lName */) //shouldn't compile without lName todo fix #38
+    .groupBy(userId, fName /*, lName */ ) //shouldn't compile without lName todo fix #38
 }
 object ShopSchema extends Sql { self =>
   import self.ColumnSet._


### PR DESCRIPTION
partially fixes #37 - requires `deleteFrom` to be a source table, doesn't address how we support deleting from a join; raised #43 for this