### PR TITLE
Add features to read

### DIFF
--- a/zio-sql/jvm/src/main/scala/Sql.scala
+++ b/zio-sql/jvm/src/main/scala/Sql.scala
@@ -372,7 +372,7 @@ trait Sql {
 
     def ++[F2, A1 <: A, C <: SelectionSet[A1]](
       that: Selection[F2, A1, C]
-    ): Selection[F :||: F2, A1, self.value.Append[A1, C]] =
+    ): Selection[F :><: F2, A1, self.value.Append[A1, C]] =
       Selection(self.value ++ that.value)
 
     def columns[A1 <: A]: value.SelectionsRepr[A1, SelectionType] = value.selections[A1, SelectionType]
@@ -527,6 +527,7 @@ trait Sql {
   }
 
   type :||:[A, B] = Features.Union[A, B]
+  type :><:[A, B] = Features.UnionColumns[A, B]
 
   /**
    * Models a function `A => B`.
@@ -621,9 +622,9 @@ trait Sql {
   }
 
   object Features {
-    type SingleColumnSelect[_]
     type Aggregated[_]
     type Union[_, _]
+    type UnionColumns[_, _]
     type Source
     type Literal
 
@@ -632,9 +633,10 @@ trait Sql {
     object IsAggregated {
       def apply[A](implicit is: IsAggregated[A]): IsAggregated[A] = is
 
-      implicit def AggregatedIsAggregated[A]: IsAggregated[Aggregated[A]] = ???
+      implicit def AggregatedIsAggregated[A]: IsAggregated[Aggregated[A]] = new IsAggregated[Aggregated[A]] {}
 
-      implicit def UnionIsAggregated[A: IsAggregated, B: IsAggregated]: IsAggregated[Union[A, B]] = ???
+      implicit def UnionIsAggregated[A: IsAggregated, B: IsAggregated]: IsAggregated[UnionColumns[A, B]] =
+        new IsAggregated[UnionColumns[A, B]] {}
     }
 
     @implicitNotFound("You can only use this function on a column in the source table")

--- a/zio-sql/jvm/src/main/scala/zio/sql/Examples.scala
+++ b/zio-sql/jvm/src/main/scala/zio/sql/Examples.scala
@@ -25,9 +25,18 @@ object Examples {
   val basicDelete = deleteFrom(users).where(fName === "Terrence")
 
   /*
-    val deleteFromWithSubquery = deleteFrom(orders).where(fkUserId in {
-      select(userId as "id") from users where (fName === "Fred") //todo fix issue #36
-    }) */
+  val singleColumnSelect = select(userId) from users where (fName === "Fred")
+
+  val deleteFromWithSubquery = deleteFrom(orders).where(fkUserId in {
+    singleColumnSelect //todo fix issue #36
+  })
+  */
+
+  //delete from users where first_name in ('Fred', 'Terrance')
+  val deleteFromWithLiteral =
+    deleteFrom(users) where (fName in {
+      Read.lit("Fred", "Terrance") //todo make syntax nicer #52
+    })
 
   //select first_name, last_name, order_date from users left join orders on users.usr_id = orders.usr_id
   val basicJoin = select {

--- a/zio-sql/jvm/src/main/scala/zio/sql/Examples.scala
+++ b/zio-sql/jvm/src/main/scala/zio/sql/Examples.scala
@@ -52,9 +52,9 @@ object Examples {
 
   val orderValues =
     (select {
-      (Arbitrary(userId)) ++
-        (Arbitrary(fName)) ++
-        (Arbitrary(lName)) ++
+      Arbitrary(userId) ++
+        Arbitrary(fName) ++
+        Arbitrary(lName) ++
         (Sum(quantity * unitPrice) as "total_spend")
     }
       from {


### PR DESCRIPTION
@jdegoes @kitlangton I had a go at changing Read to  "extend [F (features) to] its siblings to support that to surface deep featusqres up into a Read." as suggested by @jdegoes in #46 which seemed to work fine (that's the first commit here). 

I explored bringing the still-brilliantly named `Inable` to the party but I'm getting an error "Examples.scala:29:57: a type was inferred to be `Any`; this may indicate a programming error. [29:57]" VS Code knows the types (IJ of course doesn't stand a chance here) so I think this may be a compiler error (perhaps related to https://github.com/scala/bug/issues/11798 ?)

Regardless of solving this issue, I don't think we're going to have much luck with the current encoding as there are too many ways things get stuffed into a `Features.Union`. Fundamentally I think we're mixing abstractions together with `Union`. It's used to represent the features of multiple columns but also used for all the variations of `FunctionCall` which `Union`s the `Features` of all the parameters, so Substring on a single column is going to have several levels of `Union` for the one column.

Would it be a reasonable approach to have a few different type of Unions (e.g. one for adding columns, one for adding rows i.e. SQL's union, one for the various function parameters) to avoid this ambiguity?