### PR TITLE
Add GCD, LCM, CBRT, Degrees, Div, Factorial to PostgresFunctionDef

### DIFF
--- a/postgres/src/main/scala/zio/sql/postgresql/PostgresModule.scala
+++ b/postgres/src/main/scala/zio/sql/postgresql/PostgresModule.scala
@@ -8,6 +8,12 @@ trait PostgresModule extends Jdbc { self =>
 
   object PostgresFunctionDef {
     val Sind = FunctionDef[Double, Double](FunctionName("sind"))
+    val GCD = FunctionDef[(Double, Double), Double](FunctionName("gcd"))
+    val LCM = FunctionDef[(Double, Double), Double](FunctionName("lcm"))
+    val CBRT = FunctionDef[Double, Double](FunctionName("cbrt"))
+    val Degrees = FunctionDef[Double, Double](FunctionName("degrees"))
+    val Div = FunctionDef[(Double, Double), Double](FunctionName("div"))
+    val Factorial = FunctionDef[Int, Int](FunctionName("factorial"))
   }
 
   override def renderRead(read: self.Read[_]): String = {

--- a/postgres/src/main/scala/zio/sql/postgresql/PostgresModule.scala
+++ b/postgres/src/main/scala/zio/sql/postgresql/PostgresModule.scala
@@ -7,12 +7,12 @@ import zio.sql.Jdbc
 trait PostgresModule extends Jdbc { self =>
 
   object PostgresFunctionDef {
-    val Sind = FunctionDef[Double, Double](FunctionName("sind"))
-    val GCD = FunctionDef[(Double, Double), Double](FunctionName("gcd"))
-    val LCM = FunctionDef[(Double, Double), Double](FunctionName("lcm"))
-    val CBRT = FunctionDef[Double, Double](FunctionName("cbrt"))
-    val Degrees = FunctionDef[Double, Double](FunctionName("degrees"))
-    val Div = FunctionDef[(Double, Double), Double](FunctionName("div"))
+    val Sind      = FunctionDef[Double, Double](FunctionName("sind"))
+    val GCD       = FunctionDef[(Double, Double), Double](FunctionName("gcd"))
+    val LCM       = FunctionDef[(Double, Double), Double](FunctionName("lcm"))
+    val CBRT      = FunctionDef[Double, Double](FunctionName("cbrt"))
+    val Degrees   = FunctionDef[Double, Double](FunctionName("degrees"))
+    val Div       = FunctionDef[(Double, Double), Double](FunctionName("div"))
     val Factorial = FunctionDef[Int, Int](FunctionName("factorial"))
   }
 

--- a/postgres/src/test/scala/zio/sql/postgresql/FunctionDefSpec.scala
+++ b/postgres/src/test/scala/zio/sql/postgresql/FunctionDefSpec.scala
@@ -36,6 +36,84 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
       } yield assert(r.head)(equalTo(expected))
 
       assertion.mapErrorCause(cause => Cause.stackless(cause.untraced))
+    },
+    testM("gcd") {
+      val query = select(GCD(1071D, 462D)) from customers
+
+      val expected = 21D
+
+      val testResult = execute(query).to[Double, Double](identity)
+
+      val assertion = for {
+        r <- testResult.runCollect
+      } yield assert(r.head)(equalTo(expected))
+
+      assertion.mapErrorCause(cause => Cause.stackless(cause.untraced))
+    },
+    testM("lcm") {
+      val query = select(LCM(1071D, 462D)) from customers
+
+      val expected = 23562D
+
+      val testResult = execute(query).to[Double, Double](identity)
+
+      val assertion = for {
+        r <- testResult.runCollect
+      } yield assert(r.head)(equalTo(expected))
+
+      assertion.mapErrorCause(cause => Cause.stackless(cause.untraced))
+    },
+    testM("cbrt") {
+      val query = select(CBRT(64.0)) from customers
+
+      val expected = 4D
+
+      val testResult = execute(query).to[Double, Double](identity)
+
+      val assertion = for {
+        r <- testResult.runCollect
+      } yield assert(r.head)(equalTo(expected))
+
+      assertion.mapErrorCause(cause => Cause.stackless(cause.untraced))
+    },
+    testM("degrees") {
+      val query = select(Degrees(0.5)) from customers
+
+      val expected = 28.64788975654116
+
+      val testResult = execute(query).to[Double, Double](identity)
+
+      val assertion = for {
+        r <- testResult.runCollect
+      } yield assert(r.head)(equalTo(expected))
+
+      assertion.mapErrorCause(cause => Cause.stackless(cause.untraced))
+    },
+    testM("div") {
+      val query = select(Div(8D, 4D)) from customers
+
+      val expected = 2D
+
+      val testResult = execute(query).to[Double, Double](identity)
+
+      val assertion = for {
+        r <- testResult.runCollect
+      } yield assert(r.head)(equalTo(expected))
+
+      assertion.mapErrorCause(cause => Cause.stackless(cause.untraced))
+    },
+    testM("factorial") {
+      val query = select(Factorial(5)) from customers
+
+      val expected = 120
+
+      val testResult = execute(query).to[Int, Int](identity)
+
+      val assertion = for {
+        r <- testResult.runCollect
+      } yield assert(r.head)(equalTo(expected))
+
+      assertion.mapErrorCause(cause => Cause.stackless(cause.untraced))
     }
   )
 }

--- a/postgres/src/test/scala/zio/sql/postgresql/FunctionDefSpec.scala
+++ b/postgres/src/test/scala/zio/sql/postgresql/FunctionDefSpec.scala
@@ -38,9 +38,9 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
       assertion.mapErrorCause(cause => Cause.stackless(cause.untraced))
     },
     testM("gcd") {
-      val query = select(GCD(1071D, 462D)) from customers
+      val query = select(GCD(1071d, 462d)) from customers
 
-      val expected = 21D
+      val expected = 21d
 
       val testResult = execute(query).to[Double, Double](identity)
 
@@ -51,9 +51,9 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
       assertion.mapErrorCause(cause => Cause.stackless(cause.untraced))
     },
     testM("lcm") {
-      val query = select(LCM(1071D, 462D)) from customers
+      val query = select(LCM(1071d, 462d)) from customers
 
-      val expected = 23562D
+      val expected = 23562d
 
       val testResult = execute(query).to[Double, Double](identity)
 
@@ -66,7 +66,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
     testM("cbrt") {
       val query = select(CBRT(64.0)) from customers
 
-      val expected = 4D
+      val expected = 4d
 
       val testResult = execute(query).to[Double, Double](identity)
 
@@ -90,9 +90,9 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
       assertion.mapErrorCause(cause => Cause.stackless(cause.untraced))
     },
     testM("div") {
-      val query = select(Div(8D, 4D)) from customers
+      val query = select(Div(8d, 4d)) from customers
 
-      val expected = 2D
+      val expected = 2d
 
       val testResult = execute(query).to[Double, Double](identity)
 


### PR DESCRIPTION
Add GCD, LCM, CBRT, Degrees, Div, Factorial to PostgresFunctionDef
Fixes: #172 , #171 , #170 , #169 , #168 , #167 