### PR TITLE
Add 'pg_client_encoding' function to PostgresModule #191

### DIFF
--- a/postgres/src/main/scala/zio/sql/postgresql/PostgresModule.scala
+++ b/postgres/src/main/scala/zio/sql/postgresql/PostgresModule.scala
@@ -40,6 +40,7 @@ trait PostgresModule extends Jdbc { self =>
     val LPad                        = FunctionDef[(String, Int, String), String](FunctionName("lpad"))
     val RPad                        = FunctionDef[(String, Int, String), String](FunctionName("rpad"))
     val ToTimestamp                 = FunctionDef[Long, ZonedDateTime](FunctionName("to_timestamp"))
+    val PgClientEncoding            = FunctionDef[Nothing, String](FunctionName("pg_client_encoding"))
   }
 
   override def renderRead(read: self.Read[_]): String = {

--- a/postgres/src/test/scala/zio/sql/postgresql/FunctionDefSpec.scala
+++ b/postgres/src/test/scala/zio/sql/postgresql/FunctionDefSpec.scala
@@ -843,6 +843,17 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
         t2 <- assertM(runTest("hello", "xy"))(equalTo("hello"))
         t3 <- assertM(runTest("hello world", "xy"))(equalTo("hello"))
       } yield t1 && t2 && t3).mapErrorCause(cause => Cause.stackless(cause.untraced))
+    },
+    testM("pg_client_encoding") {
+      val query = select(PgClientEncoding()) from customers
+
+      val testResult = execute(query).to[String, String](identity)
+
+      val assertion = for {
+        r <- testResult.runCollect
+      } yield assert(r.head)(equalTo("UTF8"))
+
+      assertion.mapErrorCause(cause => Cause.stackless(cause.untraced))
     }
   )
 


### PR DESCRIPTION
That's my first PR ever on open source project, so just let me know if I messed up something obvious. My concerns:
1. FunctionCall0 was already implemented, so I rebased it on changes here: https://github.com/zio/zio-sql/pull/286/
2. I followed similar design like in Random(), but honestly I'm not convinced to using `select(PgClientEncoding()) from customers`. IMO it should be fine to just use it without 'from': `SELECT pg_client_encoding();` but I had no idea how to achieve that.