### PR TITLE
add missing dependencies to module pattern

### DIFF
--- a/core/jvm/src/main/scala/zio/sql/delete.scala
+++ b/core/jvm/src/main/scala/zio/sql/delete.scala
@@ -1,6 +1,6 @@
 package zio.sql
 
-trait DeleteModule { self: ExprModule with TableModule =>
+trait DeleteModule { self: ExprModule with TableModule with SelectModule =>
 
   sealed case class Delete[A](table: Table.Aux[A], whereExpr: Expr[_, A, Boolean]) {
     def where[F](expr: Expr[F, A, Boolean]): Delete[A] = Delete(table, expr)

--- a/core/jvm/src/main/scala/zio/sql/update.scala
+++ b/core/jvm/src/main/scala/zio/sql/update.scala
@@ -1,6 +1,6 @@
 package zio.sql
 
-trait UpdateModule { self: ExprModule with TableModule =>
+trait UpdateModule { self: ExprModule with TableModule with SelectModule =>
 
   sealed case class UpdateBuilder[A](table: Table.Aux[A]) {
     def set[F: Features.IsSource, Value: TypeTag](lhs: Expr[F, A, Value], rhs: Expr[_, A, Value]): Update[A] =

--- a/jdbc/src/main/scala/zio/sql/transaction.scala
+++ b/jdbc/src/main/scala/zio/sql/transaction.scala
@@ -2,7 +2,7 @@ package zio.sql
 
 import zio.{ Cause, ZIO }
 
-trait TransactionModule { self: SelectModule with DeleteModule with UpdateModule =>
+trait TransactionModule { self: SelectModule with DeleteModule with UpdateModule with ExprModule with TableModule =>
 
   import Transaction._
 


### PR DESCRIPTION
I am not entirely sure why, but Scala 3 needs these modules to be available in order to compile. Strange that Scala 2 does not also require them :-) It could of course also be a bug in Scala 3 so take this with a grain of salt :-) 