### PR TITLE
Postgres specs cleanup

### DIFF
--- a/postgres/src/main/scala/zio/sql/postgresql/PostgresModule.scala
+++ b/postgres/src/main/scala/zio/sql/postgresql/PostgresModule.scala
@@ -232,21 +232,18 @@ trait PostgresModule extends Jdbc { self =>
   override def renderRead(read: self.Read[_]): String = {
     implicit val render: Renderer = Renderer()
     PostgresRenderModule.renderReadImpl(read)
-    println(render.toString)
     render.toString
   }
 
   def renderUpdate(update: Update[_]): String = {
     implicit val render: Renderer = Renderer()
     PostgresRenderModule.renderUpdateImpl(update)
-    println(render.toString)
     render.toString
   }
 
   override def renderDelete(delete: Delete[_]): String = {
     implicit val render: Renderer = Renderer()
     PostgresRenderModule.renderDeleteImpl(delete)
-    println(render.toString)
     render.toString
   }
 
@@ -306,14 +303,14 @@ trait PostgresModule extends Jdbc { self =>
           ) // todo fix `cast` infers correctly but map doesn't work for some reason
         case tt @ TChar           =>
           render("'", tt.cast(lit.value), "'") //todo is this the same as a string? fix escaping
-        case tt @ TInstant        => render("TIMESTAMP '", tt.cast(lit.value), "'") //todo test
-        case tt @ TLocalDate      => render(tt.cast(lit.value))                     // todo still broken
-        case tt @ TLocalDateTime  => render(tt.cast(lit.value))                     // todo still broken
-        case tt @ TLocalTime      => render(tt.cast(lit.value))                     // todo still broken
-        case tt @ TOffsetDateTime => render(tt.cast(lit.value))                     // todo still broken
-        case tt @ TOffsetTime     => render(tt.cast(lit.value))                     // todo still broken
-        case tt @ TUUID           => render(tt.cast(lit.value))                     // todo still broken
-        case tt @ TZonedDateTime  => render(tt.cast(lit.value))                     // todo still broken
+        case tt @ TInstant        => render("TIMESTAMP '", tt.cast(lit.value), "'")
+        case tt @ TLocalDate      => render("DATE '", tt.cast(lit.value), "'")
+        case tt @ TLocalDateTime  => render("DATE '", tt.cast(lit.value), "'")
+        case tt @ TLocalTime      => render(tt.cast(lit.value)) // todo still broken
+        case tt @ TOffsetDateTime => render("DATE '", tt.cast(lit.value), "'")
+        case tt @ TOffsetTime     => render(tt.cast(lit.value)) // todo still broken
+        case tt @ TUUID           => render("'", tt.cast(lit.value), "'")
+        case tt @ TZonedDateTime  => render("DATE '", tt.cast(lit.value), "'")
 
         case TByte       => render(lit.value)           //default toString is probably ok
         case TBigDecimal => render(lit.value)           //default toString is probably ok

--- a/postgres/src/test/scala/zio/sql/postgresql/DeleteSpec.scala
+++ b/postgres/src/test/scala/zio/sql/postgresql/DeleteSpec.scala
@@ -4,15 +4,13 @@ import zio.Cause
 import zio.test.Assertion._
 import zio.test._
 
-import scala.language.postfixOps
-
 object DeleteSpec extends PostgresRunnableSpec with ShopSchema {
 
   import Customers._
 
   override def specLayered = suite("Postgres module delete")(
     testM("Can delete from single table with a condition") {
-      val query = deleteFrom(customers) where (verified isNotTrue)
+      val query = deleteFrom(customers).where(verified.isNotTrue)
 
       val result = execute(query)
 

--- a/postgres/src/test/scala/zio/sql/postgresql/DeleteSpec.scala
+++ b/postgres/src/test/scala/zio/sql/postgresql/DeleteSpec.scala
@@ -13,7 +13,6 @@ object DeleteSpec extends PostgresRunnableSpec with ShopSchema {
   override def specLayered = suite("Postgres module delete")(
     testM("Can delete from single table with a condition") {
       val query = deleteFrom(customers) where (verified isNotTrue)
-      println(renderDelete(query))
 
       val result = execute(query)
 

--- a/postgres/src/test/scala/zio/sql/postgresql/FunctionDefSpec.scala
+++ b/postgres/src/test/scala/zio/sql/postgresql/FunctionDefSpec.scala
@@ -37,7 +37,6 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
 
       //note: a plain number (3) would and should not compile
       val query = select(ConcatWs4("+", "1", "2", "3")) from customers
-      println(renderRead(query))
 
       val expected = Seq( // note: one for each row
         "1+2+3",
@@ -55,7 +54,6 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
 
       // note: you can't use customerId here as it is a UUID, hence not a string in our book
       val query = select(ConcatWs3(Customers.fName, Customers.fName, Customers.lName)) from customers
-      println(renderRead(query))
 
       val expected = Seq(
         "RonaldRonaldRussell",
@@ -72,7 +70,6 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
       import Expr._
 
       val query = select(ConcatWs4(" ", "Person:", Customers.fName, Customers.lName)) from customers
-      println(renderRead(query))
 
       val expected = Seq(
         "Person: Ronald Russell",
@@ -91,7 +88,6 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
       val query = select(
         ConcatWs3(" and ", Concat("Name: ", Customers.fName), Concat("Surname: ", Customers.lName))
       ) from customers
-      println(renderRead(query))
 
       val expected = Seq(
         "Name: Ronald and Surname: Russell",

--- a/postgres/src/test/scala/zio/sql/postgresql/PostgresModuleSpec.scala
+++ b/postgres/src/test/scala/zio/sql/postgresql/PostgresModuleSpec.scala
@@ -19,7 +19,7 @@ object PostgresModuleSpec extends PostgresRunnableSpec with ShopSchema {
     case class Customer(id: UUID, fname: String, lname: String, verified: Boolean, dateOfBirth: LocalDate)
 
     val query =
-      select(customerId ++ fName ++ lName ++ verified ++ dob) from customers where (condition)
+      select(customerId ++ fName ++ lName ++ verified ++ dob).from(customers).where(condition)
 
     val expected =
       Seq(
@@ -50,7 +50,7 @@ object PostgresModuleSpec extends PostgresRunnableSpec with ShopSchema {
     testM("Can select from single table") {
       case class Customer(id: UUID, fname: String, lname: String, dateOfBirth: LocalDate)
 
-      val query = select(customerId ++ fName ++ lName ++ dob) from customers
+      val query = select(customerId ++ fName ++ lName ++ dob).from(customers)
 
       val expected =
         Seq(
@@ -131,7 +131,7 @@ object PostgresModuleSpec extends PostgresRunnableSpec with ShopSchema {
     //    val orderDetailUnitPrice = BigDecimal(80.0)
     //    val condition            = (quantity === orderDetailQuantity) && (unitPrice === orderDetailUnitPrice)
     //    val query                =
-    //      select(fkOrderId ++ fkProductId ++ quantity ++ unitPrice) from orderDetails where (condition)
+    //      select(fkOrderId ++ fkProductId ++ quantity ++ unitPrice).from(orderDetails).where(condition)
 
     //    println(renderRead(query))
 
@@ -158,7 +158,7 @@ object PostgresModuleSpec extends PostgresRunnableSpec with ShopSchema {
     testM("Can select from single table with limit, offset and order by") {
       case class Customer(id: UUID, fname: String, lname: String, dateOfBirth: LocalDate)
 
-      val query = (select(customerId ++ fName ++ lName ++ dob) from customers).limit(1).offset(1).orderBy(fName)
+      val query = select(customerId ++ fName ++ lName ++ dob).from(customers).limit(1).offset(1).orderBy(fName)
 
       val expected =
         Seq(
@@ -184,7 +184,7 @@ object PostgresModuleSpec extends PostgresRunnableSpec with ShopSchema {
       assertion.mapErrorCause(cause => Cause.stackless(cause.untraced))
     },
     testM("Can count rows") {
-      val query = select(Count(customerId)) from customers
+      val query = select(Count(customerId)).from(customers)
 
       val expected = 5L
 
@@ -195,7 +195,7 @@ object PostgresModuleSpec extends PostgresRunnableSpec with ShopSchema {
       } yield assert(r.head)(equalTo(expected))
     },
     testM("Can select from joined tables (inner join)") {
-      val query = select(fName ++ lName ++ orderDate) from (customers join orders).on(fkCustomerId === customerId)
+      val query = select(fName ++ lName ++ orderDate).from(customers.join(orders).on(fkCustomerId === customerId))
 
       case class Row(firstName: String, lastName: String, orderDate: LocalDate)
 
@@ -243,7 +243,7 @@ object PostgresModuleSpec extends PostgresRunnableSpec with ShopSchema {
     testM("Can select using like") {
       case class Customer(id: UUID, fname: String, lname: String, dateOfBirth: LocalDate)
 
-      val query = select(customerId ++ fName ++ lName ++ dob) from customers where (fName like "Jo%")
+      val query = select(customerId ++ fName ++ lName ++ dob).from(customers).where(fName like "Jo%")
 
       val expected = Seq(
         Customer(
@@ -268,7 +268,7 @@ object PostgresModuleSpec extends PostgresRunnableSpec with ShopSchema {
       assertion.mapErrorCause(cause => Cause.stackless(cause.untraced))
     },
     testM("Transactions is returning the last value") {
-      val query = select(customerId) from customers
+      val query = select(customerId).from(customers)
 
       val result = execute(
         ZTransaction(query) *> ZTransaction(query)
@@ -279,7 +279,7 @@ object PostgresModuleSpec extends PostgresRunnableSpec with ShopSchema {
       assertion.mapErrorCause(cause => Cause.stackless(cause.untraced))
     },
     testM("Transaction is failing") {
-      val query = select(customerId) from customers
+      val query = select(customerId).from(customers)
 
       val result = execute(
         ZTransaction(query) *> ZTransaction.fail(new Exception("failing")) *> ZTransaction(query)

--- a/postgres/src/test/scala/zio/sql/postgresql/PostgresModuleSpec.scala
+++ b/postgres/src/test/scala/zio/sql/postgresql/PostgresModuleSpec.scala
@@ -1,6 +1,6 @@
 package zio.sql.postgresql
 
-import java.time.LocalDate
+import java.time._
 import java.util.UUID
 
 import zio._
@@ -11,6 +11,7 @@ import scala.language.postfixOps
 
 object PostgresModuleSpec extends PostgresRunnableSpec with ShopSchema {
 
+  import AggregationDef._
   import Customers._
   import Orders._
 
@@ -19,8 +20,6 @@ object PostgresModuleSpec extends PostgresRunnableSpec with ShopSchema {
 
     val query =
       select(customerId ++ fName ++ lName ++ verified ++ dob) from customers where (condition)
-
-    println(renderRead(query))
 
     val expected =
       Seq(
@@ -52,8 +51,6 @@ object PostgresModuleSpec extends PostgresRunnableSpec with ShopSchema {
       case class Customer(id: UUID, fname: String, lname: String, dateOfBirth: LocalDate)
 
       val query = select(customerId ++ fName ++ lName ++ dob) from customers
-
-      println(renderRead(query))
 
       val expected =
         Seq(
@@ -89,8 +86,6 @@ object PostgresModuleSpec extends PostgresRunnableSpec with ShopSchema {
           )
         )
 
-//      execute(query ++ query ++ query ++ query)
-
       val testResult = execute(
         query
           .to[UUID, String, String, LocalDate, Customer] { case row =>
@@ -107,66 +102,63 @@ object PostgresModuleSpec extends PostgresRunnableSpec with ShopSchema {
     testM("Can select with property unary operator") {
       customerSelectJoseAssertion(verified isNotTrue)
     },
-// TODO: uncomment when #311 (rendering literals) will be fixed
-//    testM("Can select with property binary operator with UUID") {
-//      customerSelectJoseAssertion(customerId === UUID.fromString("636ae137-5b1a-4c8c-b11f-c47c624d9cdc"))
-//    },
-//    testM("Can select with property binary operator with String") {
-//      customerSelectJoseAssertion(fName === "Jose")
-//    },
-//    testM("Can select with property binary operator with LocalDate") {
-//      customerSelectJoseAssertion(dob === LocalDate.parse("1987-03-23"))
-//    },
-//    testM("Can select with property binary operator with LocalDateTime") {
-//      customerSelectJoseAssertion(dob === LocalDateTime.parse("1987-03-23T00:00:00"))
-//    },
-//    testM("Can select with property binary operator with OffsetDateTime") {
-//      customerSelectJoseAssertion(dob === OffsetDateTime.parse("1987-03-23T00:00:00Z"))
-//    },
-//    testM("Can select with property binary operator with ZonedLocalDate") {
-//      customerSelectJoseAssertion(dob === ZonedDateTime.parse("1987-03-23T00:00:00Z"))
-//    },
-//    testM("Can select with property binary operator with Instant") {
-//      customerSelectJoseAssertion(dob === Instant.parse("1987-03-23T00:00:00Z"))
-//    },
-//    testM("Can select with property binary operator with numbers") {
-//      case class OrderDetails(orderId: UUID, product_id: UUID, quantity: Int, unitPrice: BigDecimal)
-//
-//      val orderDetailQuantity  = 3
-//      val orderDetailUnitPrice = BigDecimal(80.0)
-//      val condition            = (quantity === orderDetailQuantity) && (unitPrice === orderDetailUnitPrice)
-//      val query                =
-//        select(fkOrderId ++ fkProductId ++ quantity ++ unitPrice) from orderDetails where (condition)
-//
-//      println(renderRead(query))
-//
-//      val expected =
-//        Seq(
-//          OrderDetails(
-//            UUID.fromString("763a7c39-833f-4ee8-9939-e80dfdbfc0fc"),
-//            UUID.fromString("105a2701-ef93-4e25-81ab-8952cc7d9daa"),
-//            orderDetailQuantity,
-//            orderDetailUnitPrice
-//          )
-//        )
-//
-//      val testResult = execute(query)
-//        .to[UUID, UUID, Int, BigDecimal, OrderDetails] { case row =>
-//          OrderDetails(row._1, row._2, row._3, row._4)
-//        }
-//
-//      val assertion = for {
-//        r <- testResult.runCollect
-//      } yield assert(r)(hasSameElementsDistinct(expected))
-//
-//      assertion.mapErrorCause(cause => Cause.stackless(cause.untraced))
-//    },
+    testM("Can select with property binary operator with UUID") {
+      customerSelectJoseAssertion(customerId === UUID.fromString("636ae137-5b1a-4c8c-b11f-c47c624d9cdc"))
+    },
+    testM("Can select with property binary operator with String") {
+      customerSelectJoseAssertion(fName === "Jose")
+    },
+    testM("Can select with property binary operator with LocalDate") {
+      customerSelectJoseAssertion(dob === LocalDate.parse("1987-03-23"))
+    },
+    testM("Can select with property binary operator with LocalDateTime") {
+      customerSelectJoseAssertion(dob === LocalDateTime.parse("1987-03-23T00:00:00"))
+    },
+    testM("Can select with property binary operator with OffsetDateTime") {
+      customerSelectJoseAssertion(dob === OffsetDateTime.parse("1987-03-23T00:00:00Z"))
+    },
+    testM("Can select with property binary operator with ZonedLocalDate") {
+      customerSelectJoseAssertion(dob === ZonedDateTime.parse("1987-03-23T00:00:00Z"))
+    },
+    testM("Can select with property binary operator with Instant") {
+      customerSelectJoseAssertion(dob === Instant.parse("1987-03-23T00:00:00Z"))
+    },
+    // uncomment when we properly handle Postgres' Money type
+    //  testM("Can select with property binary operator with numbers") {
+    //    case class OrderDetails(orderId: UUID, product_id: UUID, quantity: Int, unitPrice: BigDecimal)
+
+    //    val orderDetailQuantity  = 3
+    //    val orderDetailUnitPrice = BigDecimal(80.0)
+    //    val condition            = (quantity === orderDetailQuantity) && (unitPrice === orderDetailUnitPrice)
+    //    val query                =
+    //      select(fkOrderId ++ fkProductId ++ quantity ++ unitPrice) from orderDetails where (condition)
+
+    //    println(renderRead(query))
+
+    //    val expected =
+    //      Seq(
+    //        OrderDetails(
+    //          UUID.fromString("763a7c39-833f-4ee8-9939-e80dfdbfc0fc"),
+    //          UUID.fromString("105a2701-ef93-4e25-81ab-8952cc7d9daa"),
+    //          orderDetailQuantity,
+    //          orderDetailUnitPrice
+    //        )
+    //      )
+
+    //    val testResult = execute(query.to[UUID, UUID, Int, BigDecimal, OrderDetails] { case row =>
+    //        OrderDetails(row._1, row._2, row._3, row._4)
+    //      })
+
+    //    val assertion = for {
+    //      r <- testResult.runCollect
+    //    } yield assert(r)(hasSameElementsDistinct(expected))
+
+    //    assertion.mapErrorCause(cause => Cause.stackless(cause.untraced))
+    //  },
     testM("Can select from single table with limit, offset and order by") {
       case class Customer(id: UUID, fname: String, lname: String, dateOfBirth: LocalDate)
 
       val query = (select(customerId ++ fName ++ lName ++ dob) from customers).limit(1).offset(1).orderBy(fName)
-
-      println(renderRead(query))
 
       val expected =
         Seq(
@@ -191,25 +183,19 @@ object PostgresModuleSpec extends PostgresRunnableSpec with ShopSchema {
 
       assertion.mapErrorCause(cause => Cause.stackless(cause.untraced))
     },
-    /*
-     * This is a failing test for aggregation function.
-     * Uncomment it when aggregation function handling is fixed.
-     */
-    // testM("Can count rows") {
-    //   val query = select { Count(userId) } from users
+    testM("Can count rows") {
+      val query = select(Count(customerId)) from customers
 
-    //   val expected = 5L
+      val expected = 5L
 
-    //   val result = new ExecuteBuilder(query).to[Long, Long](identity).provideCustomLayer(executorLayer)
+      val result = execute(query.to[Long, Long](identity))
 
-    //   for {
-    //     r <- result.runCollect
-    //   } yield assert(r.head)(equalTo(expected))
-    // },
+      for {
+        r <- result.runCollect
+      } yield assert(r.head)(equalTo(expected))
+    },
     testM("Can select from joined tables (inner join)") {
       val query = select(fName ++ lName ++ orderDate) from (customers join orders).on(fkCustomerId === customerId)
-
-      println(renderRead(query))
 
       case class Row(firstName: String, lastName: String, orderDate: LocalDate)
 
@@ -259,7 +245,6 @@ object PostgresModuleSpec extends PostgresRunnableSpec with ShopSchema {
 
       val query = select(customerId ++ fName ++ lName ++ dob) from customers where (fName like "Jo%")
 
-      println(renderRead(query))
       val expected = Seq(
         Customer(
           UUID.fromString("636ae137-5b1a-4c8c-b11f-c47c624d9cdc"),


### PR DESCRIPTION
- Fix commented tests
- Remove println
- Change query syntax to dot-based