### PR TITLE
Make it compile with ZIO 2.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -24,7 +24,7 @@ addCommandAlias("fmtOnce", "all scalafmtSbt scalafmt test:scalafmt")
 addCommandAlias("fmt", "fmtOnce;fmtOnce")
 addCommandAlias("check", "all scalafmtSbtCheck scalafmtCheck test:scalafmtCheck")
 
-val zioVersion                 = "1.0.7"
+val zioVersion                 = "2.0.0-M6-2"
 val testcontainersVersion      = "1.16.0"
 val testcontainersScalaVersion = "0.39.5"
 

--- a/core/shared/src/test/scala/zio-sql/HelloWorldSpec.scala
+++ b/core/shared/src/test/scala/zio-sql/HelloWorldSpec.scala
@@ -1,23 +1,21 @@
 package zio.sql
 
 import zio._
-import zio.console._
 import zio.test._
 import zio.test.Assertion._
-import zio.test.environment._
 
 import HelloWorld._
 
 object HelloWorld {
 
-  def sayHello: ZIO[Console, Nothing, Unit] =
-    console.putStrLn("Hello, World!")
+  def sayHello: ZIO[Console, Throwable, Unit] =
+    Console.printLine("Hello, World!")
 }
 
 object HelloWorldSpec extends DefaultRunnableSpec {
 
   def spec = suite("HelloWorldSpec")(
-    testM("sayHello correctly displays output") {
+    test("sayHello correctly displays output") {
       for {
         _      <- sayHello
         output <- TestConsole.output

--- a/jdbc/src/main/scala/zio/sql/ConnectionPool.scala
+++ b/jdbc/src/main/scala/zio/sql/ConnectionPool.scala
@@ -5,8 +5,6 @@ import java.sql._
 
 import zio.stm._
 import zio._
-import zio.blocking._
-import zio.clock._
 
 trait ConnectionPool {
 
@@ -23,15 +21,14 @@ object ConnectionPool {
    * A live layer for `ConnectionPool` that creates a JDBC connection pool
    * from the specified connection pool settings.
    */
-  val live: ZLayer[Has[ConnectionPoolConfig] with Blocking with Clock, IOException, Has[ConnectionPool]] =
+  val live: ZLayer[ConnectionPoolConfig with Clock, IOException, ConnectionPool] =
     (for {
       config    <- ZManaged.service[ConnectionPoolConfig]
-      blocking  <- ZManaged.service[Blocking.Service]
-      clock     <- ZManaged.service[Clock.Service]
-      queue     <- TQueue.bounded[TPromise[Nothing, ResettableConnection]](config.queueCapacity).commit.toManaged_
-      available <- TRef.make(List.empty[ResettableConnection]).commit.toManaged_
-      pool       = ConnectionPoolLive(queue, available, config, clock, blocking)
-      _         <- pool.initialize.toManaged_
+      clock     <- ZManaged.service[Clock]
+      queue     <- TQueue.bounded[TPromise[Nothing, ResettableConnection]](config.queueCapacity).commit.toManaged
+      available <- TRef.make(List.empty[ResettableConnection]).commit.toManaged
+      pool       = ConnectionPoolLive(queue, available, config, clock)
+      _         <- pool.initialize.toManaged
       _         <- ZManaged.finalizer(pool.close.orDie)
     } yield pool).toLayer
 }
@@ -49,15 +46,14 @@ final case class ConnectionPoolLive(
   queue: TQueue[TPromise[Nothing, ResettableConnection]],
   available: TRef[List[ResettableConnection]],
   config: ConnectionPoolConfig,
-  clock: Clock.Service,
-  blocking: Blocking.Service
+  clock: Clock,
 ) extends ConnectionPool {
 
   /**
    * Adds a fresh connection to the connection pool.
    */
   val addFreshConnection: IO[IOException, ResettableConnection] = {
-    val makeConnection = blocking.effectBlocking {
+    val makeConnection = ZIO.attemptBlocking {
       val connection = DriverManager.getConnection(config.url, config.properties)
 
       val autoCommit  = config.autoCommit
@@ -80,7 +76,7 @@ final case class ConnectionPoolLive(
     }.refineToOrDie[IOException]
 
     for {
-      connection <- makeConnection.retry(config.retryPolicy).provide(Has(clock))
+      connection <- makeConnection.retry(config.retryPolicy).provideEnvironment(ZEnvironment(clock))
       _          <- available.update(connection :: _).commit
     } yield connection
   }
@@ -91,17 +87,15 @@ final case class ConnectionPoolLive(
   val close: IO[IOException, Any] =
     ZIO.uninterruptible {
       available.get.commit.flatMap { all =>
-        blocking.blocking {
-          ZIO.foreachPar(all) { connection =>
-            ZIO(connection.connection.close()).refineToOrDie[IOException]
-          }
+        ZIO.foreachPar(all) { connection =>
+          ZIO.attemptBlocking(connection.connection.close()).refineToOrDie[IOException]
         }
       }
     }
 
   def connection: Managed[Exception, Connection] =
     ZManaged
-      .make(tryTake.commit.flatMap {
+      .acquireReleaseWith(tryTake.commit.flatMap {
         case Left(promise) =>
           ZIO.interruptible(promise.await.commit).onInterrupt {
             promise.poll.flatMap {
@@ -115,7 +109,7 @@ final case class ConnectionPoolLive(
         case Right(connection) =>
           ZIO.succeed(connection)
       })(release(_))
-      .flatMap(rc => rc.reset.toManaged_.as(rc.connection))
+      .flatMap(rc => rc.reset.toManaged.as(rc.connection))
 
   /**
    * Initializes the connection pool.
@@ -123,7 +117,7 @@ final case class ConnectionPoolLive(
   val initialize: IO[IOException, Unit] =
     ZIO.uninterruptible {
       ZIO
-        .foreachPar_(1 to config.poolSize) { _ =>
+        .foreachParDiscard(1 to config.poolSize) { _ =>
           addFreshConnection
         }
         .unit

--- a/jdbc/src/main/scala/zio/sql/ConnectionPool.scala
+++ b/jdbc/src/main/scala/zio/sql/ConnectionPool.scala
@@ -46,7 +46,7 @@ final case class ConnectionPoolLive(
   queue: TQueue[TPromise[Nothing, ResettableConnection]],
   available: TRef[List[ResettableConnection]],
   config: ConnectionPoolConfig,
-  clock: Clock,
+  clock: Clock
 ) extends ConnectionPool {
 
   /**

--- a/jdbc/src/main/scala/zio/sql/ConnectionPoolConfig.scala
+++ b/jdbc/src/main/scala/zio/sql/ConnectionPoolConfig.scala
@@ -1,7 +1,6 @@
 package zio.sql
 
-import zio.Schedule
-import zio.duration._
+import zio.{Schedule, durationInt}
 
 /**
  * Configuration information for the connection pool.

--- a/jdbc/src/main/scala/zio/sql/ConnectionPoolConfig.scala
+++ b/jdbc/src/main/scala/zio/sql/ConnectionPoolConfig.scala
@@ -1,6 +1,6 @@
 package zio.sql
 
-import zio.{Schedule, durationInt}
+import zio.{ durationInt, Schedule }
 
 /**
  * Configuration information for the connection pool.

--- a/jdbc/src/main/scala/zio/sql/SqlDriverLiveModule.scala
+++ b/jdbc/src/main/scala/zio/sql/SqlDriverLiveModule.scala
@@ -3,7 +3,6 @@ package zio.sql
 import java.sql._
 
 import zio._
-import zio.blocking.Blocking
 import zio.stream.{ Stream, ZStream }
 
 trait SqlDriverLiveModule { self: Jdbc =>
@@ -15,14 +14,14 @@ trait SqlDriverLiveModule { self: Jdbc =>
     def readOn[A](read: Read[A], conn: Connection): Stream[Exception, A]
   }
 
-  sealed case class SqlDriverLive(blocking: Blocking.Service, pool: ConnectionPool)
+  sealed case class SqlDriverLive(pool: ConnectionPool)
       extends SqlDriver
       with SqlDriverCore { self =>
     def delete(delete: Delete[_]): IO[Exception, Int] =
       pool.connection.use(deleteOn(delete, _))
 
     def deleteOn(delete: Delete[_], conn: Connection): IO[Exception, Int] =
-      blocking.effectBlocking {
+      ZIO.attemptBlocking {
         val query     = renderDelete(delete)
         val statement = conn.createStatement()
         statement.executeUpdate(query)
@@ -32,7 +31,7 @@ trait SqlDriverLiveModule { self: Jdbc =>
       pool.connection.use(updateOn(update, _))
 
     def updateOn(update: Update[_], conn: Connection): IO[Exception, Int] =
-      blocking.effectBlocking {
+      ZIO.attemptBlocking {
 
         val query = renderUpdate(update)
 
@@ -51,7 +50,7 @@ trait SqlDriverLiveModule { self: Jdbc =>
 
     override def readOn[A](read: Read[A], conn: Connection): Stream[Exception, A] =
       Stream.unwrap {
-        blocking.effectBlocking {
+        ZIO.attemptBlocking {
           val schema = getColumns(read).zipWithIndex.map { case (value, index) =>
             (value, index + 1)
           } // SQL is 1-based indexing
@@ -66,7 +65,7 @@ trait SqlDriverLiveModule { self: Jdbc =>
             val resultSet = statement.getResultSet()
 
             ZStream
-              .unfoldM(resultSet) { rs =>
+              .unfoldZIO(resultSet) { rs =>
                 if (rs.next()) {
                   try unsafeExtractRow[read.ResultType](resultSet, schema) match {
                     case Left(error)  => ZIO.fail(error)
@@ -85,8 +84,8 @@ trait SqlDriverLiveModule { self: Jdbc =>
     override def transact[R, A](tx: ZTransaction[R, Exception, A]): ZManaged[R, Exception, A] =
       for {
         connection <- pool.connection
-        _          <- blocking.effectBlocking(connection.setAutoCommit(false)).refineToOrDie[Exception].toManaged_
-        a          <- tx.run(blocking, Txn(connection, self))
+        _          <- ZIO.attemptBlocking(connection.setAutoCommit(false)).refineToOrDie[Exception].toManaged
+        a          <- tx.run(Txn(connection, self))
       } yield a
   }
 }

--- a/jdbc/src/main/scala/zio/sql/SqlDriverLiveModule.scala
+++ b/jdbc/src/main/scala/zio/sql/SqlDriverLiveModule.scala
@@ -14,9 +14,7 @@ trait SqlDriverLiveModule { self: Jdbc =>
     def readOn[A](read: Read[A], conn: Connection): Stream[Exception, A]
   }
 
-  sealed case class SqlDriverLive(pool: ConnectionPool)
-      extends SqlDriver
-      with SqlDriverCore { self =>
+  sealed case class SqlDriverLive(pool: ConnectionPool) extends SqlDriver with SqlDriverCore { self =>
     def delete(delete: Delete[_]): IO[Exception, Int] =
       pool.connection.use(deleteOn(delete, _))
 

--- a/jdbc/src/main/scala/zio/sql/TransactionModule.scala
+++ b/jdbc/src/main/scala/zio/sql/TransactionModule.scala
@@ -2,66 +2,63 @@ package zio.sql
 
 import java.sql._
 
-import zio._
-import zio.blocking.Blocking
+import zio.{Tag => ZTag, _}
 import zio.stream._
 
 trait TransactionModule { self: Jdbc =>
   private[sql] sealed case class Txn(connection: Connection, sqlDriverCore: SqlDriverCore)
 
-  sealed case class ZTransaction[-R, +E, +A](unwrap: ZManaged[(R, Txn), E, A]) { self =>
+  sealed case class ZTransaction[-R: ZTag: IsNotIntersection, +E, +A](unwrap: ZManaged[(R, Txn), E, A]) { self =>
     def map[B](f: A => B): ZTransaction[R, E, B] =
       ZTransaction(self.unwrap.map(f))
 
-    def flatMap[R1 <: R, E1 >: E, B](f: A => ZTransaction[R1, E1, B]): ZTransaction[R1, E1, B] =
+    def flatMap[R1 <: R: ZTag: IsNotIntersection, E1 >: E, B](f: A => ZTransaction[R1, E1, B]): ZTransaction[R1, E1, B] =
       ZTransaction(self.unwrap.flatMap(a => f(a).unwrap))
 
-    private[sql] def run(blocking: Blocking.Service, txn: Txn)(implicit
+    private[sql] def run(txn: Txn)(implicit
       ev: E <:< Exception
     ): ZManaged[R, Exception, A] =
       for {
         r <- ZManaged.environment[R]
         a <- self.unwrap
                .mapError(ev)
-               .provide((r, txn))
+               .provideEnvironment(ZEnvironment((r.get, txn)))
                .tapBoth(
                  _ =>
-                   blocking
-                     .effectBlocking(txn.connection.rollback())
+                   ZIO.attemptBlocking(txn.connection.rollback())
                      .refineToOrDie[Exception]
-                     .toManaged_,
+                     .toManaged,
                  _ =>
-                   blocking
-                     .effectBlocking(txn.connection.commit())
+                   ZIO.attemptBlocking(txn.connection.commit())
                      .refineToOrDie[Exception]
-                     .toManaged_
+                     .toManaged
                )
       } yield a
 
-    def zip[R1 <: R, E1 >: E, B](tx: ZTransaction[R1, E1, B]): ZTransaction[R1, E1, (A, B)] =
+    def zip[R1 <: R: ZTag: IsNotIntersection, E1 >: E, B](tx: ZTransaction[R1, E1, B]): ZTransaction[R1, E1, (A, B)] =
       zipWith[R1, E1, B, (A, B)](tx)((_, _))
 
-    def zipWith[R1 <: R, E1 >: E, B, C](tx: ZTransaction[R1, E1, B])(f: (A, B) => C): ZTransaction[R1, E1, C] =
+    def zipWith[R1 <: R: ZTag: IsNotIntersection, E1 >: E, B, C](tx: ZTransaction[R1, E1, B])(f: (A, B) => C): ZTransaction[R1, E1, C] =
       for {
         a <- self
         b <- tx
       } yield f(a, b)
 
-    def *>[R1 <: R, E1 >: E, B](tx: ZTransaction[R1, E1, B]): ZTransaction[R1, E1, B] =
+    def *>[R1 <: R: ZTag: IsNotIntersection, E1 >: E, B](tx: ZTransaction[R1, E1, B]): ZTransaction[R1, E1, B] =
       self.flatMap(_ => tx)
 
     // named alias for *>
-    def zipRight[R1 <: R, E1 >: E, B](tx: ZTransaction[R1, E1, B]): ZTransaction[R1, E1, B] =
+    def zipRight[R1 <: R: ZTag: IsNotIntersection, E1 >: E, B](tx: ZTransaction[R1, E1, B]): ZTransaction[R1, E1, B] =
       self *> tx
 
-    def <*[R1 <: R, E1 >: E, B](tx: ZTransaction[R1, E1, B]): ZTransaction[R1, E1, A] =
+    def <*[R1 <: R: ZTag: IsNotIntersection, E1 >: E, B](tx: ZTransaction[R1, E1, B]): ZTransaction[R1, E1, A] =
       self.flatMap(a => tx.map(_ => a))
 
     // named alias for <*
-    def zipLeft[R1 <: R, E1 >: E, B](tx: ZTransaction[R1, E1, B]): ZTransaction[R1, E1, A] =
+    def zipLeft[R1 <: R: ZTag: IsNotIntersection, E1 >: E, B](tx: ZTransaction[R1, E1, B]): ZTransaction[R1, E1, A] =
       self <* tx
 
-    def catchAllCause[R1 <: R, E1 >: E, A1 >: A](f: Cause[E1] => ZTransaction[R1, E1, A1]): ZTransaction[R1, E1, A1] =
+    def catchAllCause[R1 <: R: ZTag: IsNotIntersection, E1 >: E, A1 >: A](f: Cause[E1] => ZTransaction[R1, E1, A1]): ZTransaction[R1, E1, A1] =
       ZTransaction(self.unwrap.catchAllCause(cause => f(cause).unwrap))
   }
 
@@ -91,15 +88,15 @@ trait TransactionModule { self: Jdbc =>
 
     def fail[E](e: => E): ZTransaction[Any, E, Nothing] = fromEffect(ZIO.fail(e))
 
-    def halt[E](e: => Cause[E]): ZTransaction[Any, E, Nothing] = fromEffect(ZIO.halt(e))
+    def halt[E](e: => Cause[E]): ZTransaction[Any, E, Nothing] = fromEffect(ZIO.failCause(e))
 
-    def fromEffect[R, E, A](zio: ZIO[R, E, A]): ZTransaction[R, E, A] =
+    def fromEffect[R: ZTag: IsNotIntersection, E, A](zio: ZIO[R, E, A]): ZTransaction[R, E, A] =
       ZTransaction(for {
         tuple <- ZManaged.environment[(R, Txn)]
-        a     <- zio.provide(tuple._1).toManaged_
+        a     <- zio.provideEnvironment(ZEnvironment(tuple.get._1)).toManaged
       } yield a)
 
     private val txn: ZTransaction[Any, Nothing, Txn] =
-      ZTransaction(ZManaged.environment[(Any, Txn)].map(_._2))
+      ZTransaction(ZManaged.environment[(Any, Txn)].map(_.get._2))
   }
 }

--- a/jdbc/src/main/scala/zio/sql/jdbc.scala
+++ b/jdbc/src/main/scala/zio/sql/jdbc.scala
@@ -1,6 +1,6 @@
 package zio.sql
 
-import zio.{Tag => ZTag, _}
+import zio.{ Tag => ZTag, _ }
 import zio.stream._
 
 trait Jdbc extends zio.sql.Sql with TransactionModule with JdbcInternalModule with SqlDriverLiveModule {
@@ -16,11 +16,13 @@ trait Jdbc extends zio.sql.Sql with TransactionModule with JdbcInternalModule wi
   object SqlDriver {
     val live: ZLayer[ConnectionPool, Nothing, SqlDriver] =
       (for {
-        pool     <- ZIO.service[ConnectionPool]
+        pool <- ZIO.service[ConnectionPool]
       } yield SqlDriverLive(pool)).toLayer
   }
 
-  def execute[R <: SqlDriver: ZTag: IsNotIntersection, A](tx: ZTransaction[R, Exception, A]): ZManaged[R, Exception, A] =
+  def execute[R <: SqlDriver: ZTag: IsNotIntersection, A](
+    tx: ZTransaction[R, Exception, A]
+  ): ZManaged[R, Exception, A] =
     ZManaged.environmentWithManaged[R](_.get.transact(tx))
 
   def execute[A](read: Read[A]): ZStream[SqlDriver, Exception, A] =

--- a/jdbc/src/main/scala/zio/sql/jdbc.scala
+++ b/jdbc/src/main/scala/zio/sql/jdbc.scala
@@ -1,7 +1,6 @@
 package zio.sql
 
-import zio._
-import zio.blocking.Blocking
+import zio.{Tag => ZTag, _}
 import zio.stream._
 
 trait Jdbc extends zio.sql.Sql with TransactionModule with JdbcInternalModule with SqlDriverLiveModule {
@@ -15,21 +14,20 @@ trait Jdbc extends zio.sql.Sql with TransactionModule with JdbcInternalModule wi
     def transact[R, A](tx: ZTransaction[R, Exception, A]): ZManaged[R, Exception, A]
   }
   object SqlDriver {
-    val live: ZLayer[Blocking with Has[ConnectionPool], Nothing, Has[SqlDriver]] =
+    val live: ZLayer[ConnectionPool, Nothing, SqlDriver] =
       (for {
-        blocking <- ZIO.service[Blocking.Service]
         pool     <- ZIO.service[ConnectionPool]
-      } yield SqlDriverLive(blocking, pool)).toLayer
+      } yield SqlDriverLive(pool)).toLayer
   }
 
-  def execute[R <: Has[SqlDriver], A](tx: ZTransaction[R, Exception, A]): ZManaged[R, Exception, A] =
-    ZManaged.accessManaged[R](_.get.transact(tx))
+  def execute[R <: SqlDriver: ZTag: IsNotIntersection, A](tx: ZTransaction[R, Exception, A]): ZManaged[R, Exception, A] =
+    ZManaged.environmentWithManaged[R](_.get.transact(tx))
 
-  def execute[A](read: Read[A]): ZStream[Has[SqlDriver], Exception, A] =
-    ZStream.unwrap(ZIO.access[Has[SqlDriver]](_.get.read(read)))
+  def execute[A](read: Read[A]): ZStream[SqlDriver, Exception, A] =
+    ZStream.unwrap(ZIO.environmentWith[SqlDriver](_.get.read(read)))
 
-  def execute(delete: Delete[_]): ZIO[Has[SqlDriver], Exception, Int] =
-    ZIO.accessM[Has[SqlDriver]](
+  def execute(delete: Delete[_]): ZIO[SqlDriver, Exception, Int] =
+    ZIO.environmentWithZIO[SqlDriver](
       _.get.delete(delete)
     )
 }

--- a/mysql/src/test/scala/zio/sql/mysql/DeleteSpec.scala
+++ b/mysql/src/test/scala/zio/sql/mysql/DeleteSpec.scala
@@ -9,7 +9,7 @@ object DeleteSpec extends MysqlRunnableSpec with ShopSchema {
   import Customers._
 
   override def specLayered = suite("MySQL module delete")(
-    testM("Can delete from single table with a condition") {
+    test("Can delete from single table with a condition") {
       val query = deleteFrom(customers).where(verified.isNotTrue)
 
       val result = execute(query)

--- a/mysql/src/test/scala/zio/sql/mysql/FunctionDefSpec.scala
+++ b/mysql/src/test/scala/zio/sql/mysql/FunctionDefSpec.scala
@@ -11,7 +11,7 @@ object FunctionDefSpec extends MysqlRunnableSpec with ShopSchema {
   import MysqlFunctionDef._
 
   override def specLayered = suite("MySQL FunctionDef")(
-    testM("lower") {
+    test("lower") {
       val query = select(Lower(fName)) from customers limit (1)
 
       val expected = "ronald"
@@ -27,7 +27,7 @@ object FunctionDefSpec extends MysqlRunnableSpec with ShopSchema {
     // FIXME: lower with string literal should not refer to a column name
     // See: https://www.w3schools.com/sql/trymysql.asp?filename=trysql_func_mysql_lower
     // Uncomment the following test when fixed
-    //    testM("lower with string literal") {
+    //    test("lower with string literal") {
     //      val query = select(Lower("LOWER")) from customers limit(1)
     //
     //      val expected = "lower"
@@ -40,7 +40,7 @@ object FunctionDefSpec extends MysqlRunnableSpec with ShopSchema {
     //
     //      assertion.mapErrorCause(cause => Cause.stackless(cause.untraced))
     //    },
-    testM("sin") {
+    test("sin") {
       val query = select(Sin(1.0))
 
       val expected = 0.8414709848078965
@@ -53,7 +53,7 @@ object FunctionDefSpec extends MysqlRunnableSpec with ShopSchema {
 
       assertion.mapErrorCause(cause => Cause.stackless(cause.untraced))
     },
-    testM("abs") {
+    test("abs") {
       val query = select(Abs(-32.0))
 
       val expected = 32.0
@@ -66,7 +66,7 @@ object FunctionDefSpec extends MysqlRunnableSpec with ShopSchema {
 
       assertion.mapErrorCause(cause => Cause.stackless(cause.untraced))
     },
-    testM("crc32") {
+    test("crc32") {
       val query = select(Crc32("MySQL")) from customers
 
       val expected = 3259397556L
@@ -79,7 +79,7 @@ object FunctionDefSpec extends MysqlRunnableSpec with ShopSchema {
 
       assertion.mapErrorCause(cause => Cause.stackless(cause.untraced))
     },
-    testM("degrees") {
+    test("degrees") {
       val query = select(Degrees(Math.PI)) from customers
 
       val expected = 180d
@@ -92,7 +92,7 @@ object FunctionDefSpec extends MysqlRunnableSpec with ShopSchema {
 
       assertion.mapErrorCause(cause => Cause.stackless(cause.untraced))
     },
-    testM("log2") {
+    test("log2") {
       val query = select(Log2(8d)) from customers
 
       val expected = 3d
@@ -105,7 +105,7 @@ object FunctionDefSpec extends MysqlRunnableSpec with ShopSchema {
 
       assertion.mapErrorCause(cause => Cause.stackless(cause.untraced))
     },
-    testM("log10") {
+    test("log10") {
       val query = select(Log10(1000000d)) from customers
 
       val expected = 6d
@@ -118,7 +118,7 @@ object FunctionDefSpec extends MysqlRunnableSpec with ShopSchema {
 
       assertion.mapErrorCause(cause => Cause.stackless(cause.untraced))
     },
-    testM("pi") {
+    test("pi") {
       val query = select(Pi) from customers
 
       val expected = 3.141593d

--- a/mysql/src/test/scala/zio/sql/mysql/MysqlModuleTest.scala
+++ b/mysql/src/test/scala/zio/sql/mysql/MysqlModuleTest.scala
@@ -14,7 +14,7 @@ object MysqlModuleTest extends MysqlRunnableSpec with ShopSchema {
   import this.Orders._
 
   override def specLayered = suite("Mysql module")(
-    testM("Can select from single table") {
+    test("Can select from single table") {
       case class Customer(id: UUID, fname: String, lname: String, dateOfBirth: LocalDate)
 
       val query = select(customerId ++ fName ++ lName ++ dob) from customers
@@ -68,7 +68,7 @@ object MysqlModuleTest extends MysqlRunnableSpec with ShopSchema {
 
       assertion.mapErrorCause(cause => Cause.stackless(cause.untraced))
     },
-    testM("Can select with property operator") {
+    test("Can select with property operator") {
       case class Customer(id: UUID, fname: String, lname: String, verified: Boolean, dateOfBirth: LocalDate)
 
       val query = select(customerId ++ fName ++ lName ++ verified ++ dob) from customers where (verified isNotTrue)
@@ -99,7 +99,7 @@ object MysqlModuleTest extends MysqlRunnableSpec with ShopSchema {
 
       assertion.mapErrorCause(cause => Cause.stackless(cause.untraced))
     },
-    testM("Can select from single table with limit, offset and order by") {
+    test("Can select from single table with limit, offset and order by") {
       case class Customer(id: UUID, fname: String, lname: String, dateOfBirth: LocalDate)
 
       val query = (select(customerId ++ fName ++ lName ++ dob) from customers).limit(1).offset(1).orderBy(fName)
@@ -133,7 +133,7 @@ object MysqlModuleTest extends MysqlRunnableSpec with ShopSchema {
      * This is a failing test for aggregation function.
      * Uncomment it when aggregation function handling is fixed.
      */
-    // testM("Can count rows") {
+    // test("Can count rows") {
     //   val query = select { Count(userId) } from users
 
     //   val expected = 5L
@@ -144,7 +144,7 @@ object MysqlModuleTest extends MysqlRunnableSpec with ShopSchema {
     //     r <- result.runCollect
     //   } yield assert(r.head)(equalTo(expected))
     // },
-    testM("Can select from joined tables (inner join)") {
+    test("Can select from joined tables (inner join)") {
       val query = select(fName ++ lName ++ orderDate) from (customers join orders).on(
         fkCustomerId === customerId
       ) where (verified isNotTrue)

--- a/mysql/src/test/scala/zio/sql/mysql/MysqlRunnableSpec.scala
+++ b/mysql/src/test/scala/zio/sql/mysql/MysqlRunnableSpec.scala
@@ -4,7 +4,7 @@ import java.util.Properties
 
 import zio._
 import zio.sql._
-import zio.test.environment.TestEnvironment
+import zio.test.TestEnvironment
 import zio.test._
 
 trait MysqlRunnableSpec extends JdbcRunnableSpec with MysqlModule {
@@ -18,10 +18,17 @@ trait MysqlRunnableSpec extends JdbcRunnableSpec with MysqlModule {
 
   val poolConfigLayer = TestContainer
     .mysql()
-    .map(a => Has(ConnectionPoolConfig(a.get.jdbcUrl, connProperties(a.get.username, a.get.password))))
+    .map(a =>
+      ZEnvironment(
+        ConnectionPoolConfig(
+          a.get.jdbcUrl,
+          connProperties(a.get.username, a.get.password)
+        )
+      )
+    )
 
   override def spec: Spec[TestEnvironment, TestFailure[Any], TestSuccess] =
-    specLayered.provideCustomLayerShared(jdbcLayer)
+    specLayered.provideCustomShared(jdbcLayer)
 
   def specLayered: Spec[JdbcEnvironment, TestFailure[Object], TestSuccess]
 

--- a/mysql/src/test/scala/zio/sql/mysql/TransactionSpec.scala
+++ b/mysql/src/test/scala/zio/sql/mysql/TransactionSpec.scala
@@ -20,9 +20,10 @@ object TransactionSpec extends MysqlRunnableSpec with ShopSchema {
       ).use(ZIO.succeed(_))
 
       val assertion =
-        result.flatMap(_.runCount)
-        .map(count => assertTrue(count == 5))
-        .orDie
+        result
+          .flatMap(_.runCount)
+          .map(count => assertTrue(count == 5))
+          .orDie
 
       assertion.mapErrorCause(cause => Cause.stackless(cause.untraced))
     },

--- a/mysql/src/test/scala/zio/sql/mysql/TransactionSpec.scala
+++ b/mysql/src/test/scala/zio/sql/mysql/TransactionSpec.scala
@@ -11,19 +11,22 @@ object TransactionSpec extends MysqlRunnableSpec with ShopSchema {
 
   import Customers._
 
-  override def specLayered = suite("MySQL module")(
-    testM("Transaction is returning the last value") {
+  override def specLayered: Spec[JdbcEnvironment, TestFailure[Object], TestSuccess] = suite("MySQL module")(
+    test("Transaction is returning the last value") {
       val query = select(customerId) from customers
 
       val result = execute(
         ZTransaction(query) *> ZTransaction(query)
       ).use(ZIO.succeed(_))
 
-      val assertion = assertM(result.flatMap(_.runCount))(equalTo(5L)).orDie
+      val assertion =
+        result.flatMap(_.runCount)
+        .map(count => assertTrue(count == 5))
+        .orDie
 
       assertion.mapErrorCause(cause => Cause.stackless(cause.untraced))
     },
-    testM("Transaction is failing") {
+    test("Transaction is failing") {
       val query = select(customerId) from customers
 
       val result = execute(
@@ -32,30 +35,30 @@ object TransactionSpec extends MysqlRunnableSpec with ShopSchema {
 
       assertM(result.flip)(equalTo("failing")).mapErrorCause(cause => Cause.stackless(cause.untraced))
     },
-    testM("Transaction failed and didn't deleted rows") {
+    test("Transaction failed and didn't deleted rows") {
       val query       = select(customerId) from customers
       val deleteQuery = deleteFrom(customers).where(verified === false)
 
       val result = (for {
-        allCustomersCount       <- execute(query.to(identity[UUID](_))).runCount.toManaged_
+        allCustomersCount       <- execute(query.to(identity[UUID](_))).runCount.toManaged
         _                       <- execute(
                                      ZTransaction(deleteQuery) *> ZTransaction.fail(new Exception("this is error")) *> ZTransaction(query)
                                    ).catchAllCause(_ => ZManaged.succeed("continue"))
-        remainingCustomersCount <- execute(query.to(identity[UUID](_))).runCount.toManaged_
+        remainingCustomersCount <- execute(query.to(identity[UUID](_))).runCount.toManaged
       } yield (allCustomersCount, remainingCustomersCount)).use(ZIO.succeed(_))
 
       assertM(result)(equalTo((5L, 5L))).mapErrorCause(cause => Cause.stackless(cause.untraced))
     },
-    testM("Transaction succeeded and deleted rows") {
+    test("Transaction succeeded and deleted rows") {
       val query       = select(customerId) from customers
       val deleteQuery = deleteFrom(customers).where(verified === false)
 
       val tx = ZTransaction(deleteQuery)
 
       val result = (for {
-        allCustomersCount       <- execute(query.to(identity[UUID](_))).runCount.toManaged_
+        allCustomersCount       <- execute(query.to(identity[UUID](_))).runCount.toManaged
         _                       <- execute(tx)
-        remainingCustomersCount <- execute(query.to(identity[UUID](_))).runCount.toManaged_
+        remainingCustomersCount <- execute(query.to(identity[UUID](_))).runCount.toManaged
       } yield (allCustomersCount, remainingCustomersCount)).use(ZIO.succeed(_))
 
       assertM(result)(equalTo((5L, 4L))).mapErrorCause(cause => Cause.stackless(cause.untraced))

--- a/postgres/src/test/scala/zio/sql/postgresql/DeleteSpec.scala
+++ b/postgres/src/test/scala/zio/sql/postgresql/DeleteSpec.scala
@@ -9,7 +9,7 @@ object DeleteSpec extends PostgresRunnableSpec with ShopSchema {
   import Customers._
 
   override def specLayered = suite("Postgres module delete")(
-    testM("Can delete from single table with a condition") {
+    test("Can delete from single table with a condition") {
       val query = deleteFrom(customers).where(verified.isNotTrue)
 
       val result = execute(query)

--- a/postgres/src/test/scala/zio/sql/postgresql/PostgresModuleSpec.scala
+++ b/postgres/src/test/scala/zio/sql/postgresql/PostgresModuleSpec.scala
@@ -48,7 +48,7 @@ object PostgresModuleSpec extends PostgresRunnableSpec with ShopSchema {
   }
 
   override def specLayered = suite("Postgres module")(
-    testM("Can select from single table") {
+    test("Can select from single table") {
       case class Customer(id: UUID, fname: String, lname: String, dateOfBirth: LocalDate)
 
       val query = select(customerId ++ fName ++ lName ++ dob).from(customers)
@@ -100,32 +100,32 @@ object PostgresModuleSpec extends PostgresRunnableSpec with ShopSchema {
 
       assertion.mapErrorCause(cause => Cause.stackless(cause.untraced))
     },
-    testM("Can select with property unary operator") {
+    test("Can select with property unary operator") {
       customerSelectJoseAssertion(verified isNotTrue)
     },
-    testM("Can select with property binary operator with UUID") {
+    test("Can select with property binary operator with UUID") {
       customerSelectJoseAssertion(customerId === UUID.fromString("636ae137-5b1a-4c8c-b11f-c47c624d9cdc"))
     },
-    testM("Can select with property binary operator with String") {
+    test("Can select with property binary operator with String") {
       customerSelectJoseAssertion(fName === "Jose")
     },
-    testM("Can select with property binary operator with LocalDate") {
+    test("Can select with property binary operator with LocalDate") {
       customerSelectJoseAssertion(dob === LocalDate.parse("1987-03-23"))
     },
-    testM("Can select with property binary operator with LocalDateTime") {
+    test("Can select with property binary operator with LocalDateTime") {
       customerSelectJoseAssertion(dob === LocalDateTime.parse("1987-03-23T00:00:00"))
     },
-    testM("Can select with property binary operator with OffsetDateTime") {
+    test("Can select with property binary operator with OffsetDateTime") {
       customerSelectJoseAssertion(dob === OffsetDateTime.parse("1987-03-23T00:00:00Z"))
     },
-    testM("Can select with property binary operator with ZonedLocalDate") {
+    test("Can select with property binary operator with ZonedLocalDate") {
       customerSelectJoseAssertion(dob === ZonedDateTime.parse("1987-03-23T00:00:00Z"))
     },
-    testM("Can select with property binary operator with Instant") {
+    test("Can select with property binary operator with Instant") {
       customerSelectJoseAssertion(dob === Instant.parse("1987-03-23T00:00:00Z"))
     },
     // uncomment when we properly handle Postgres' Money type
-    //  testM("Can select with property binary operator with numbers") {
+    //  test("Can select with property binary operator with numbers") {
     //    case class OrderDetails(orderId: UUID, product_id: UUID, quantity: Int, unitPrice: BigDecimal)
 
     //    val orderDetailQuantity  = 3
@@ -156,7 +156,7 @@ object PostgresModuleSpec extends PostgresRunnableSpec with ShopSchema {
 
     //    assertion.mapErrorCause(cause => Cause.stackless(cause.untraced))
     //  },
-    testM("Can select from single table with limit, offset and order by") {
+    test("Can select from single table with limit, offset and order by") {
       case class Customer(id: UUID, fname: String, lname: String, dateOfBirth: LocalDate)
 
       val query = select(customerId ++ fName ++ lName ++ dob).from(customers).limit(1).offset(1).orderBy(fName)
@@ -184,7 +184,7 @@ object PostgresModuleSpec extends PostgresRunnableSpec with ShopSchema {
 
       assertion.mapErrorCause(cause => Cause.stackless(cause.untraced))
     },
-    testM("Can count rows") {
+    test("Can count rows") {
       val query = select(Count(customerId)).from(customers)
 
       val expected = 5L
@@ -195,7 +195,7 @@ object PostgresModuleSpec extends PostgresRunnableSpec with ShopSchema {
         r <- result.runCollect
       } yield assert(r.head)(equalTo(expected))
     },
-    testM("Can select from joined tables (inner join)") {
+    test("Can select from joined tables (inner join)") {
       val query = select(fName ++ lName ++ orderDate).from(customers.join(orders).on(fkCustomerId === customerId))
 
       case class Row(firstName: String, lastName: String, orderDate: LocalDate)
@@ -241,7 +241,7 @@ object PostgresModuleSpec extends PostgresRunnableSpec with ShopSchema {
 
       assertion.mapErrorCause(cause => Cause.stackless(cause.untraced))
     },
-    testM("Can select using like") {
+    test("Can select using like") {
       case class Customer(id: UUID, fname: String, lname: String, dateOfBirth: LocalDate)
 
       val query = select(customerId ++ fName ++ lName ++ dob).from(customers).where(fName like "Jo%")
@@ -268,7 +268,7 @@ object PostgresModuleSpec extends PostgresRunnableSpec with ShopSchema {
 
       assertion.mapErrorCause(cause => Cause.stackless(cause.untraced))
     },
-    testM("Can delete from single table with a condition") {
+    test("Can delete from single table with a condition") {
       val query = deleteFrom(customers) where (verified isNotTrue)
       println(renderDelete(query))
 
@@ -280,7 +280,7 @@ object PostgresModuleSpec extends PostgresRunnableSpec with ShopSchema {
 
       assertion.mapErrorCause(cause => Cause.stackless(cause.untraced))
     },
-    testM("Can delete all from a single table") {
+    test("Can delete all from a single table") {
       val query = deleteFrom(customers)
       println(renderDelete(query))
 

--- a/postgres/src/test/scala/zio/sql/postgresql/PostgresRunnableSpec.scala
+++ b/postgres/src/test/scala/zio/sql/postgresql/PostgresRunnableSpec.scala
@@ -1,10 +1,10 @@
 package zio.sql.postgresql
 
 import zio.test._
-import zio.test.environment.TestEnvironment
+import zio.test.TestEnvironment
 import java.util.Properties
 import zio.sql.{ ConnectionPoolConfig, JdbcRunnableSpec, TestContainer }
-import zio.Has
+import zio.ZEnvironment
 
 trait PostgresRunnableSpec extends JdbcRunnableSpec with PostgresModule {
 
@@ -20,7 +20,7 @@ trait PostgresRunnableSpec extends JdbcRunnableSpec with PostgresModule {
   val poolConfigLayer = TestContainer
     .postgres()
     .map(a =>
-      Has(
+      ZEnvironment(
         ConnectionPoolConfig(
           url = a.get.jdbcUrl,
           properties = connProperties(a.get.username, a.get.password),
@@ -30,7 +30,7 @@ trait PostgresRunnableSpec extends JdbcRunnableSpec with PostgresModule {
     )
 
   override def spec: Spec[TestEnvironment, TestFailure[Any], TestSuccess] =
-    specLayered.provideCustomLayerShared(jdbcLayer)
+    specLayered.provideCustomShared(jdbcLayer)
 
   def specLayered: Spec[JdbcEnvironment, TestFailure[Object], TestSuccess]
 

--- a/postgres/src/test/scala/zio/sql/postgresql/TransactionSpec.scala
+++ b/postgres/src/test/scala/zio/sql/postgresql/TransactionSpec.scala
@@ -14,7 +14,7 @@ object TransactionSpec extends PostgresRunnableSpec with ShopSchema {
   import Customers._
 
   override def specLayered = suite("Postgres module")(
-    testM("Transaction is returning the last value") {
+    test("Transaction is returning the last value") {
       val query = select(customerId) from customers
 
       val result = execute(
@@ -25,7 +25,7 @@ object TransactionSpec extends PostgresRunnableSpec with ShopSchema {
 
       assertion.mapErrorCause(cause => Cause.stackless(cause.untraced))
     },
-    testM("Transaction is failing") {
+    test("Transaction is failing") {
       val query = select(customerId) from customers
 
       val result = execute(
@@ -34,30 +34,30 @@ object TransactionSpec extends PostgresRunnableSpec with ShopSchema {
 
       assertM(result.flip)(equalTo("failing")).mapErrorCause(cause => Cause.stackless(cause.untraced))
     },
-    testM("Transaction failed and didn't deleted rows") {
+    test("Transaction failed and didn't deleted rows") {
       val query       = select(customerId) from customers
       val deleteQuery = deleteFrom(customers).where(verified === false)
 
       val result = (for {
-        allCustomersCount       <- execute(query.to(identity[UUID](_))).runCount.toManaged_
+        allCustomersCount       <- execute(query.to(identity[UUID](_))).runCount.toManaged
         _                       <- execute(
                                      ZTransaction(deleteQuery) *> ZTransaction.fail(new Exception("this is error")) *> ZTransaction(query)
                                    ).catchAllCause(_ => ZManaged.succeed("continue"))
-        remainingCustomersCount <- execute(query.to(identity[UUID](_))).runCount.toManaged_
+        remainingCustomersCount <- execute(query.to(identity[UUID](_))).runCount.toManaged
       } yield (allCustomersCount, remainingCustomersCount)).use(ZIO.succeed(_))
 
       assertM(result)(equalTo((5L, 5L))).mapErrorCause(cause => Cause.stackless(cause.untraced))
     },
-    testM("Transaction succeeded and deleted rows") {
+    test("Transaction succeeded and deleted rows") {
       val query       = select(customerId) from customers
       val deleteQuery = deleteFrom(customers).where(verified === false)
 
       val tx = ZTransaction(deleteQuery)
 
       val result = (for {
-        allCustomersCount       <- execute(query.to(identity[UUID](_))).runCount.toManaged_
+        allCustomersCount       <- execute(query.to(identity[UUID](_))).runCount.toManaged
         _                       <- execute(tx)
-        remainingCustomersCount <- execute(query.to(identity[UUID](_))).runCount.toManaged_
+        remainingCustomersCount <- execute(query.to(identity[UUID](_))).runCount.toManaged
       } yield (allCustomersCount, remainingCustomersCount)).use(ZIO.succeed(_))
 
       assertM(result)(equalTo((5L, 4L))).mapErrorCause(cause => Cause.stackless(cause.untraced))


### PR DESCRIPTION
This PR does the minimal amount of changes to get this library too compile against the latest ZIO 2.0 milestone release.

I can include the implicit `ZTraceElement` and updating any ZIO returning functions to take in parameters by name in this PR or hold off and do it in a followup PR once this is merged. 