### PR TITLE
DSL, meta-model improvements, group by & NPE bug fixes, nullable aspect

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -79,12 +79,12 @@ lazy val core = crossProject(JSPlatform, JVMPlatform)
   .settings(buildInfoSettings("zio.sql"))
   .settings(
     libraryDependencies ++= Seq(
-      "dev.zio" %% "zio"                   % zioVersion       % Provided,
-      "dev.zio" %% "zio-streams"           % zioVersion       % Provided,
-      "dev.zio" %% "zio-schema"            % zioSchemaVersion % Provided,
-      "dev.zio" %% "zio-schema-derivation" % zioSchemaVersion % Provided,
-      "dev.zio" %% "zio-test"              % zioVersion       % Test,
-      "dev.zio" %% "zio-test-sbt"          % zioVersion       % Test
+      "dev.zio" %% "zio"                   % zioVersion,
+      "dev.zio" %% "zio-streams"           % zioVersion,
+      "dev.zio" %% "zio-schema"            % zioSchemaVersion,
+      "dev.zio" %% "zio-schema-derivation" % zioSchemaVersion,
+      "dev.zio" %% "zio-test"              % zioVersion % Test,
+      "dev.zio" %% "zio-test-sbt"          % zioVersion % Test
     )
   )
   .settings(testFrameworks += new TestFramework("zio.test.sbt.ZTestFramework"))
@@ -118,10 +118,10 @@ lazy val examples = project
     publish / skip := true,
     moduleName := "examples",
     libraryDependencies ++= Seq(
-      "dev.zio" %% "zio"                   % zioVersion       % Provided,
-      "dev.zio" %% "zio-streams"           % zioVersion       % Provided,
-      "dev.zio" %% "zio-schema"            % zioSchemaVersion % Provided,
-      "dev.zio" %% "zio-schema-derivation" % zioSchemaVersion % Provided
+      "dev.zio" %% "zio"                   % zioVersion,
+      "dev.zio" %% "zio-streams"           % zioVersion,
+      "dev.zio" %% "zio-schema"            % zioSchemaVersion,
+      "dev.zio" %% "zio-schema-derivation" % zioSchemaVersion
     )
   )
   .dependsOn(sqlserver)
@@ -132,11 +132,11 @@ lazy val driver = project
   .settings(buildInfoSettings("zio.sql.driver"))
   .settings(
     libraryDependencies ++= Seq(
-      "dev.zio" %% "zio"                   % zioVersion       % Provided,
-      "dev.zio" %% "zio-schema"            % zioSchemaVersion % Provided,
-      "dev.zio" %% "zio-schema-derivation" % zioSchemaVersion % Provided,
-      "dev.zio" %% "zio-test"              % zioVersion       % Test,
-      "dev.zio" %% "zio-test-sbt"          % zioVersion       % Test
+      "dev.zio" %% "zio"                   % zioVersion,
+      "dev.zio" %% "zio-schema"            % zioSchemaVersion,
+      "dev.zio" %% "zio-schema-derivation" % zioSchemaVersion,
+      "dev.zio" %% "zio-test"              % zioVersion % Test,
+      "dev.zio" %% "zio-test-sbt"          % zioVersion % Test
     )
   )
   .settings(testFrameworks += new TestFramework("zio.test.sbt.ZTestFramework"))
@@ -147,12 +147,12 @@ lazy val jdbc = project
   .settings(buildInfoSettings("zio.sql.jdbc"))
   .settings(
     libraryDependencies ++= Seq(
-      "dev.zio" %% "zio"                   % zioVersion       % Provided,
-      "dev.zio" %% "zio-streams"           % zioVersion       % Provided,
-      "dev.zio" %% "zio-schema"            % zioSchemaVersion % Provided,
-      "dev.zio" %% "zio-schema-derivation" % zioSchemaVersion % Provided,
-      "dev.zio" %% "zio-test"              % zioVersion       % Test,
-      "dev.zio" %% "zio-test-sbt"          % zioVersion       % Test
+      "dev.zio" %% "zio"                   % zioVersion,
+      "dev.zio" %% "zio-streams"           % zioVersion,
+      "dev.zio" %% "zio-schema"            % zioSchemaVersion,
+      "dev.zio" %% "zio-schema-derivation" % zioSchemaVersion,
+      "dev.zio" %% "zio-test"              % zioVersion % Test,
+      "dev.zio" %% "zio-test-sbt"          % zioVersion % Test
     )
   )
   .settings(testFrameworks += new TestFramework("zio.test.sbt.ZTestFramework"))
@@ -165,10 +165,10 @@ lazy val mysql = project
   .settings(buildInfoSettings("zio.sql.mysql"))
   .settings(
     libraryDependencies ++= Seq(
-      "dev.zio"           %% "zio"                        % zioVersion                 % Provided,
-      "dev.zio"           %% "zio-streams"                % zioVersion                 % Provided,
-      "dev.zio"           %% "zio-schema"                 % zioSchemaVersion           % Provided,
-      "dev.zio"           %% "zio-schema-derivation"      % zioSchemaVersion           % Provided,
+      "dev.zio"           %% "zio"                        % zioVersion,
+      "dev.zio"           %% "zio-streams"                % zioVersion,
+      "dev.zio"           %% "zio-schema"                 % zioSchemaVersion,
+      "dev.zio"           %% "zio-schema-derivation"      % zioSchemaVersion,
       "org.testcontainers" % "testcontainers"             % testcontainersVersion      % Test,
       "org.testcontainers" % "database-commons"           % testcontainersVersion      % Test,
       "org.testcontainers" % "jdbc"                       % testcontainersVersion      % Test,
@@ -186,10 +186,10 @@ lazy val oracle = project
   .settings(buildInfoSettings("zio.sql.oracle"))
   .settings(
     libraryDependencies ++= Seq(
-      "dev.zio"                 %% "zio"                                 % zioVersion                 % Provided,
-      "dev.zio"                 %% "zio-streams"                         % zioVersion                 % Provided,
-      "dev.zio"                 %% "zio-schema"                          % zioSchemaVersion           % Provided,
-      "dev.zio"                 %% "zio-schema-derivation"               % zioSchemaVersion           % Provided,
+      "dev.zio"                 %% "zio"                                 % zioVersion,
+      "dev.zio"                 %% "zio-streams"                         % zioVersion,
+      "dev.zio"                 %% "zio-schema"                          % zioSchemaVersion,
+      "dev.zio"                 %% "zio-schema-derivation"               % zioSchemaVersion,
       "org.testcontainers"       % "testcontainers"                      % testcontainersVersion      % Test,
       "org.testcontainers"       % "database-commons"                    % testcontainersVersion      % Test,
       "org.testcontainers"       % "oracle-xe"                           % testcontainersVersion      % Test,
@@ -207,10 +207,10 @@ lazy val postgres = project
   .settings(buildInfoSettings("zio.sql.postgres"))
   .settings(
     libraryDependencies ++= Seq(
-      "dev.zio"           %% "zio"                             % zioVersion                 % Provided,
-      "dev.zio"           %% "zio-streams"                     % zioVersion                 % Provided,
-      "dev.zio"           %% "zio-schema"                      % zioSchemaVersion           % Provided,
-      "dev.zio"           %% "zio-schema-derivation"           % zioSchemaVersion           % Provided,
+      "dev.zio"           %% "zio"                             % zioVersion,
+      "dev.zio"           %% "zio-streams"                     % zioVersion,
+      "dev.zio"           %% "zio-schema"                      % zioSchemaVersion,
+      "dev.zio"           %% "zio-schema-derivation"           % zioSchemaVersion,
       "org.testcontainers" % "testcontainers"                  % testcontainersVersion      % Test,
       "org.testcontainers" % "database-commons"                % testcontainersVersion      % Test,
       "org.testcontainers" % "postgresql"                      % testcontainersVersion      % Test,
@@ -228,10 +228,10 @@ lazy val sqlserver = project
   .settings(buildInfoSettings("zio.sql.sqlserver"))
   .settings(
     libraryDependencies ++= Seq(
-      "dev.zio"                %% "zio"                              % zioVersion                 % Provided,
-      "dev.zio"                %% "zio-streams"                      % zioVersion                 % Provided,
-      "dev.zio"                %% "zio-schema"                       % zioSchemaVersion           % Provided,
-      "dev.zio"                %% "zio-schema-derivation"            % zioSchemaVersion           % Provided,
+      "dev.zio"                %% "zio"                              % zioVersion,
+      "dev.zio"                %% "zio-streams"                      % zioVersion,
+      "dev.zio"                %% "zio-schema"                       % zioSchemaVersion,
+      "dev.zio"                %% "zio-schema-derivation"            % zioSchemaVersion,
       "org.testcontainers"      % "testcontainers"                   % testcontainersVersion      % Test,
       "org.testcontainers"      % "database-commons"                 % testcontainersVersion      % Test,
       "org.testcontainers"      % "mssqlserver"                      % testcontainersVersion      % Test,

--- a/core/jvm/src/main/scala/zio/sql/Sql.scala
+++ b/core/jvm/src/main/scala/zio/sql/Sql.scala
@@ -17,10 +17,10 @@ trait Sql extends SelectModule with DeleteModule with UpdateModule with ExprModu
    *
    * SELECT ARBITRARY(age), COUNT(*) FROM person GROUP BY age
    */
-  def select[F, A, B <: SelectionSet[A]](selection: Selection[F, A, B])(
-    implicit i: Features.IsPartiallyAggregated[F]
-    ): Selector[F, A, B, i.Unaggregated] =
-      Selector[F, A, B, i.Unaggregated](selection)
+  def select[F, A, B <: SelectionSet[A]](selection: Selection[F, A, B])(implicit
+    i: Features.IsPartiallyAggregated[F]
+  ): Selector[F, A, B, i.Unaggregated] =
+    Selector[F, A, B, i.Unaggregated](selection)
 
   def subselect[ParentTable]: SubselectPartiallyApplied[ParentTable] = new SubselectPartiallyApplied[ParentTable]
 

--- a/core/jvm/src/main/scala/zio/sql/Sql.scala
+++ b/core/jvm/src/main/scala/zio/sql/Sql.scala
@@ -20,6 +20,9 @@ trait Sql extends SelectModule with DeleteModule with UpdateModule with ExprModu
   def select[F, A, B <: SelectionSet[A]](selection: Selection[F, A, B]): SelectBuilder[F, A, B] =
     SelectBuilder(selection)
 
+  def select[F, A, B <: SelectionSet[A]](selection: AggSelection[F, A, B]): AggSelectBuilder[F, A, B] =
+    AggSelectBuilder(selection)
+
   def subselect[ParentTable]: SubselectPartiallyApplied[ParentTable] = new SubselectPartiallyApplied[ParentTable]
 
   def subselectFrom[ParentTable, F, Source, B <: SelectionSet[Source]](

--- a/core/jvm/src/main/scala/zio/sql/Sql.scala
+++ b/core/jvm/src/main/scala/zio/sql/Sql.scala
@@ -2,7 +2,7 @@ package zio.sql
 
 import zio.schema.Schema
 
-trait Sql extends SelectModule with DeleteModule with UpdateModule with ExprModule with TableModule with InsertModule {
+trait Sql extends SelectModule with DeleteModule with UpdateModule with ExprModule with TableModule with InsertModule with UtilsModule {
   self =>
 
   /*

--- a/core/jvm/src/main/scala/zio/sql/Sql.scala
+++ b/core/jvm/src/main/scala/zio/sql/Sql.scala
@@ -17,11 +17,10 @@ trait Sql extends SelectModule with DeleteModule with UpdateModule with ExprModu
    *
    * SELECT ARBITRARY(age), COUNT(*) FROM person GROUP BY age
    */
-  def select[F, A, B <: SelectionSet[A]](selection: Selection[F, A, B]): SelectBuilder[F, A, B] =
-    SelectBuilder(selection)
-
-  def select[F, A, B <: SelectionSet[A]](selection: AggSelection[F, A, B]): AggSelectBuilder[F, A, B] =
-    AggSelectBuilder(selection)
+  def select[F, A, B <: SelectionSet[A]](selection: Selection[F, A, B])(
+    implicit i: Features.IsPartiallyAggregated[F]
+    ): Selector[F, A, B, i.Unaggregated] =
+      Selector[F, A, B, i.Unaggregated](selection)
 
   def subselect[ParentTable]: SubselectPartiallyApplied[ParentTable] = new SubselectPartiallyApplied[ParentTable]
 

--- a/core/jvm/src/main/scala/zio/sql/Sql.scala
+++ b/core/jvm/src/main/scala/zio/sql/Sql.scala
@@ -2,7 +2,14 @@ package zio.sql
 
 import zio.schema.Schema
 
-trait Sql extends SelectModule with DeleteModule with UpdateModule with ExprModule with TableModule with InsertModule with UtilsModule {
+trait Sql
+    extends SelectModule
+    with DeleteModule
+    with UpdateModule
+    with ExprModule
+    with TableModule
+    with InsertModule
+    with UtilsModule {
   self =>
 
   /*
@@ -43,12 +50,12 @@ trait Sql extends SelectModule with DeleteModule with UpdateModule with ExprModu
 
   def renderUpdate(update: self.Update[_]): String
 
-  def insertInto[F, Source, AllColumnIdentities, B <: SelectionSet.Aux[Source, ColsRepr], ColsRepr](
+  def insertInto[F, Source, AllColumnIdentities, B <: SelectionSet[Source]](
     table: Table.Source.Aux_[Source, AllColumnIdentities]
   )(
-    sources: Selection.Aux[F, Source, B, ColsRepr]
+    sources: Selection[F, Source, B]
   ) =
-    InsertBuilder(table, sources)
+    InsertBuilder[F, Source, AllColumnIdentities, B, sources.ColsRepr](table, sources)
 
   def renderInsert[A: Schema](insert: self.Insert[_, A]): String
 }

--- a/core/jvm/src/main/scala/zio/sql/expr.scala
+++ b/core/jvm/src/main/scala/zio/sql/expr.scala
@@ -85,7 +85,7 @@ trait ExprModule extends NewtypesModule with FeaturesModule with OpsModule {
     def isNotTrue[A1 <: A](implicit ev: B <:< Boolean): Expr[F, A1, Boolean] =
       Expr.Property(self, PropertyOp.IsNotTrue)
 
-    //TODO
+    //TODO https://github.com/zio/zio-sql/issues/564
     def as[B1 >: B](name: String): Expr[F, A, B1] = {
       val _ = name
       self

--- a/core/jvm/src/main/scala/zio/sql/expr.scala
+++ b/core/jvm/src/main/scala/zio/sql/expr.scala
@@ -131,7 +131,7 @@ trait ExprModule extends NewtypesModule with FeaturesModule with OpsModule {
     ): Selection[F, A, SelectionSet.Cons[A, B, SelectionSet.Empty]] =
       Selection.computedOption[F, A, B](expr, Expr.exprName(expr))
 
-    // aggregated F should not be propagated  
+    // aggregated F should not be propagated
     sealed case class Subselect[F <: Features.Aggregated[_], Repr, Source, Subsource, Head](
       subselect: Read.Subselect[F, Repr, _ <: Source, Subsource, Head, SelectionSet.Empty]
     ) extends InvariantExpr[Features.Derived, Any, Head] {
@@ -276,13 +276,11 @@ trait ExprModule extends NewtypesModule with FeaturesModule with OpsModule {
   }
 
   object AggregationDef {
-    val Count                                            = AggregationDef[Any, Long](FunctionName("count"))
-    val Sum                                              = AggregationDef[Double, Double](FunctionName("sum"))
-    //TODO what is Arbitrary??? it does not exists on postgresql
-    def Arbitrary[F, A, B: TypeTag](expr: Expr[F, A, B]) = AggregationDef[B, B](FunctionName("arbitrary"))(expr)
-    val Avg                                              = AggregationDef[Double, Double](FunctionName("avg"))
-    def Min[F, A, B: TypeTag](expr: Expr[F, A, B])       = AggregationDef[B, B](FunctionName("min"))(expr)
-    def Max[F, A, B: TypeTag](expr: Expr[F, A, B])       = AggregationDef[B, B](FunctionName("max"))(expr)
+    val Count                                      = AggregationDef[Any, Long](FunctionName("count"))
+    val Sum                                        = AggregationDef[Double, Double](FunctionName("sum"))
+    val Avg                                        = AggregationDef[Double, Double](FunctionName("avg"))
+    def Min[F, A, B: TypeTag](expr: Expr[F, A, B]) = AggregationDef[B, B](FunctionName("min"))(expr)
+    def Max[F, A, B: TypeTag](expr: Expr[F, A, B]) = AggregationDef[B, B](FunctionName("max"))(expr)
   }
 
   sealed case class FunctionDef[-A, +B](name: FunctionName) { self =>

--- a/core/jvm/src/main/scala/zio/sql/features.scala
+++ b/core/jvm/src/main/scala/zio/sql/features.scala
@@ -2,7 +2,7 @@ package zio.sql
 
 import scala.annotation.implicitNotFound
 
-trait FeaturesModule { 
+trait FeaturesModule {
 
   type :||:[A, B] = Features.Union[A, B]
 
@@ -14,25 +14,25 @@ trait FeaturesModule {
     type Function0
     type Derived
 
-    sealed trait IsNotAggregated[A] 
+    sealed trait IsNotAggregated[A]
     object IsNotAggregated {
-      implicit def UnionIsNotAgregated[A: IsNotAggregated, B: IsNotAggregated]: IsNotAggregated[Union[A, B]] = 
+      implicit def UnionIsNotAgregated[A: IsNotAggregated, B: IsNotAggregated]: IsNotAggregated[Union[A, B]] =
         new IsNotAggregated[Union[A, B]] {}
 
-      implicit def SourceIsNotAggregated[A]: IsNotAggregated[Source[A]] = 
+      implicit def SourceIsNotAggregated[A]: IsNotAggregated[Source[A]]                                      =
         new IsNotAggregated[Source[A]] {}
 
-      implicit val LiteralIsNotAggregated: IsNotAggregated[Literal] = 
+      implicit val LiteralIsNotAggregated: IsNotAggregated[Literal]                                          =
         new IsNotAggregated[Literal] {}
 
-      implicit val DerivedIsNotAggregated: IsNotAggregated[Derived] = 
+      implicit val DerivedIsNotAggregated: IsNotAggregated[Derived]                                          =
         new IsNotAggregated[Derived] {}
 
-      implicit val Function0IsNotAggregated: IsNotAggregated[Function0] = 
+      implicit val Function0IsNotAggregated: IsNotAggregated[Function0]                                      =
         new IsNotAggregated[Function0] {}
     }
 
-    sealed trait IsFullyAggregated[A] 
+    sealed trait IsFullyAggregated[A]
 
     object IsFullyAggregated {
       def apply[A](implicit is: IsFullyAggregated[A]): IsFullyAggregated[A] = is
@@ -64,31 +64,38 @@ trait FeaturesModule {
 
       def apply[A](implicit is: IsPartiallyAggregated[A]): IsPartiallyAggregated.WithRemainder[A, is.Unaggregated] = is
 
-      implicit def AggregatedIsAggregated[A]: IsPartiallyAggregated.WithRemainder[Aggregated[A], Any] = new IsPartiallyAggregated[Aggregated[A]] {
-        override type Unaggregated = Any
-      }
+      implicit def AggregatedIsAggregated[A]: IsPartiallyAggregated.WithRemainder[Aggregated[A], Any] =
+        new IsPartiallyAggregated[Aggregated[A]] {
+          override type Unaggregated = Any
+        }
 
-      implicit def UnionIsAggregated[A, B](implicit inA: IsPartiallyAggregated[A], inB: IsPartiallyAggregated[B]): IsPartiallyAggregated.WithRemainder[Union[A, B], inA.Unaggregated with inB.Unaggregated] =
+      implicit def UnionIsAggregated[A, B](implicit
+        inA: IsPartiallyAggregated[A],
+        inB: IsPartiallyAggregated[B]
+      ): IsPartiallyAggregated.WithRemainder[Union[A, B], inA.Unaggregated with inB.Unaggregated] =
         new IsPartiallyAggregated[Union[A, B]] {
           override type Unaggregated = inA.Unaggregated with inB.Unaggregated
         }
 
-      implicit val LiteralIsAggregated: IsPartiallyAggregated.WithRemainder[Literal, Any] = new IsPartiallyAggregated[Literal] {
-        override type Unaggregated = Any
-      }
+      implicit val LiteralIsAggregated: IsPartiallyAggregated.WithRemainder[Literal, Any] =
+        new IsPartiallyAggregated[Literal] {
+          override type Unaggregated = Any
+        }
 
-      implicit val DerivedIsAggregated: IsPartiallyAggregated.WithRemainder[Derived, Any] = new IsPartiallyAggregated[Derived] {
-        override type Unaggregated = Any
-      }
-      
-      implicit val FunctionIsAggregated: IsPartiallyAggregated.WithRemainder[Function0, Any] = new IsPartiallyAggregated[Function0] {
-        override type Unaggregated = Any
-      }
+      implicit val DerivedIsAggregated: IsPartiallyAggregated.WithRemainder[Derived, Any] =
+        new IsPartiallyAggregated[Derived] {
+          override type Unaggregated = Any
+        }
+
+      implicit val FunctionIsAggregated: IsPartiallyAggregated.WithRemainder[Function0, Any] =
+        new IsPartiallyAggregated[Function0] {
+          override type Unaggregated = Any
+        }
     }
 
     trait IsPartiallyAggregatedLowPriorityImplicits {
-      implicit def SourceIsAggregated[A]: IsPartiallyAggregated.WithRemainder[Features.Source[A], Features.Source[A]] = new IsPartiallyAggregated[Features.Source[A]] {          override type Unaggregated = Features.Source[A]
-      }
+      implicit def SourceIsAggregated[A]: IsPartiallyAggregated.WithRemainder[Features.Source[A], Features.Source[A]] =
+        new IsPartiallyAggregated[Features.Source[A]] { override type Unaggregated = Features.Source[A] }
     }
   }
 }

--- a/core/jvm/src/main/scala/zio/sql/features.scala
+++ b/core/jvm/src/main/scala/zio/sql/features.scala
@@ -2,18 +2,17 @@ package zio.sql
 
 import scala.annotation.implicitNotFound
 
-trait FeaturesModule {
+trait FeaturesModule { 
 
   type :||:[A, B] = Features.Union[A, B]
 
-  object Features extends PartialAggregationLowerPrio {
+  object Features {
     type Aggregated[_]
     type Union[_, _]
     type Source[_]
-    //TODO make Derived and Join tables return Expr of type "Derived" when .columns is called
-    type Derived
     type Literal
     type Function0
+    type Derived
 
     sealed trait IsNotAggregated[A] 
     object IsNotAggregated {
@@ -23,11 +22,11 @@ trait FeaturesModule {
       implicit def SourceIsNotAggregated[A]: IsNotAggregated[Source[A]] = 
         new IsNotAggregated[Source[A]] {}
 
-      implicit val DerivedIsNotAggregated: IsNotAggregated[Derived] = 
-        new IsNotAggregated[Derived] {}
-
       implicit val LiteralIsNotAggregated: IsNotAggregated[Literal] = 
         new IsNotAggregated[Literal] {}
+
+      implicit val DerivedIsNotAggregated: IsNotAggregated[Derived] = 
+        new IsNotAggregated[Derived] {}
 
       implicit val Function0IsNotAggregated: IsNotAggregated[Function0] = 
         new IsNotAggregated[Function0] {}
@@ -40,6 +39,8 @@ trait FeaturesModule {
 
       implicit def AggregatedIsAggregated[A]: IsFullyAggregated[Aggregated[A]] = new IsFullyAggregated[Aggregated[A]] {}
 
+      implicit val LiteralIsAggregated: IsFullyAggregated[Literal] = new IsFullyAggregated[Literal] {}
+
       implicit def UnionIsAggregated[A: IsFullyAggregated, B: IsFullyAggregated]: IsFullyAggregated[Union[A, B]] =
         new IsFullyAggregated[Union[A, B]] {}
     }
@@ -50,22 +51,44 @@ trait FeaturesModule {
     object IsSource {
       implicit def isSource[ColumnIdentity]: IsSource[Source[ColumnIdentity]] = new IsSource[Source[ColumnIdentity]] {}
     }
-  }
 
-  trait PartialAggregationLowerPrio {
-    sealed trait IsPartiallyAggregated[A]
+    sealed trait IsPartiallyAggregated[A] {
+      type Unaggregated
+    }
 
-    object IsPartiallyAggregated {
+    object IsPartiallyAggregated extends IsPartiallyAggregatedLowPriorityImplicits {
+
+      type WithRemainder[F, R] = IsPartiallyAggregated[F] {
+        type Unaggregated = R
+      }
+
+      def apply[A](implicit is: IsPartiallyAggregated[A]): IsPartiallyAggregated.WithRemainder[A, is.Unaggregated] = is
+
+      implicit def AggregatedIsAggregated[A]: IsPartiallyAggregated.WithRemainder[Aggregated[A], Any] = new IsPartiallyAggregated[Aggregated[A]] {
+        override type Unaggregated = Any
+      }
+
+      implicit def UnionIsAggregated[A, B](implicit inA: IsPartiallyAggregated[A], inB: IsPartiallyAggregated[B]): IsPartiallyAggregated.WithRemainder[Union[A, B], inA.Unaggregated with inB.Unaggregated] =
+        new IsPartiallyAggregated[Union[A, B]] {
+          override type Unaggregated = inA.Unaggregated with inB.Unaggregated
+        }
+
+      implicit val LiteralIsAggregated: IsPartiallyAggregated.WithRemainder[Literal, Any] = new IsPartiallyAggregated[Literal] {
+        override type Unaggregated = Any
+      }
+
+      implicit val DerivedIsAggregated: IsPartiallyAggregated.WithRemainder[Derived, Any] = new IsPartiallyAggregated[Derived] {
+        override type Unaggregated = Any
+      }
       
-      def apply[A](implicit is: IsPartiallyAggregated[A]): IsPartiallyAggregated[A] = is
+      implicit val FunctionIsAggregated: IsPartiallyAggregated.WithRemainder[Function0, Any] = new IsPartiallyAggregated[Function0] {
+        override type Unaggregated = Any
+      }
+    }
 
-      implicit def AggregatedIsAggregated[A]: IsPartiallyAggregated[Features.Aggregated[A]] = new IsPartiallyAggregated[Features.Aggregated[A]] {}
-
-      implicit def UnionIsAggregatedInB[A, B](implicit instB: IsPartiallyAggregated[B]): IsPartiallyAggregated[Features.Union[A, B]] =
-        new IsPartiallyAggregated[Features.Union[A, B]] {}
-
-      implicit def UnionIsAggregatedInA[A, B](implicit instB: IsPartiallyAggregated[A]): IsPartiallyAggregated[Features.Union[A, B]] =
-        new IsPartiallyAggregated[Features.Union[A, B]] {}
+    trait IsPartiallyAggregatedLowPriorityImplicits {
+      implicit def SourceIsAggregated[A]: IsPartiallyAggregated.WithRemainder[Features.Source[A], Features.Source[A]] = new IsPartiallyAggregated[Features.Source[A]] {          override type Unaggregated = Features.Source[A]
+      }
     }
   }
 }

--- a/core/jvm/src/main/scala/zio/sql/insert.scala
+++ b/core/jvm/src/main/scala/zio/sql/insert.scala
@@ -15,7 +15,7 @@ import zio.schema.Schema
  */
 trait InsertModule { self: ExprModule with TableModule with SelectModule =>
 
-  sealed case class InsertBuilder[F, Source, AllColumnIdentities, B <: SelectionSet.Aux[Source, ColsRepr], ColsRepr](
+  sealed case class InsertBuilder[F, Source, AllColumnIdentities, B <: SelectionSet[Source], ColsRepr](
     table: Table.Source.Aux_[Source, AllColumnIdentities],
     sources: Selection.Aux[F, Source, B, ColsRepr]
   ) {
@@ -36,7 +36,6 @@ trait InsertModule { self: ExprModule with TableModule with SelectModule =>
   )
 
   //TODO find a way for more meaningful error messages
-  //@implicitNotFound("This insert would blow up at runtime!!!")
   sealed trait SchemaValidity[F, Z, ColsRepr, AllColumnIdentities]
 
   // format: off
@@ -45,7 +44,8 @@ trait InsertModule { self: ExprModule with TableModule with SelectModule =>
       ev1: Schema[A1],
       ev2: ColsRepr <:< (A1, Unit),
       ev3: F <:< Features.Source[Identity1],
-      ev4: AllColumnIdentities <:< Identity1
+      //TODO find other way to check if selection set contains some set of columns from table
+      ev4: AllColumnIdentities =:= Identity1
     ): SchemaValidity[F, A1, ColsRepr, AllColumnIdentities] =
       new SchemaValidity[F, A1, ColsRepr, AllColumnIdentities] {}
 
@@ -53,7 +53,7 @@ trait InsertModule { self: ExprModule with TableModule with SelectModule =>
       ev1: Schema[(A1, A2)],
       ev2: ColsRepr <:< (A1, (A2, Unit)),
       ev3: F <:< Features.Union[Features.Source[Identity1], Features.Source[Identity2]],
-      ev4: AllColumnIdentities <:< Identity1 with Identity2
+      ev4: AllColumnIdentities =:= Identity1 with Identity2
     ): SchemaValidity[F, (A1, A2), ColsRepr, AllColumnIdentities] =
       new SchemaValidity[F, (A1, A2), ColsRepr, AllColumnIdentities] {}
 
@@ -61,7 +61,7 @@ trait InsertModule { self: ExprModule with TableModule with SelectModule =>
       ev1: Schema[(A1, A2, A3)],
       ev2: ColsRepr <:< (A1, (A2, (A3, Unit))),
       ev3: F <:< Features.Union[Features.Union[Features.Source[Identity1], Features.Source[Identity2]], Features.Source[Identity3]],
-      ev4: AllColumnIdentities <:< Identity1 with Identity2 with Identity3
+      ev4: AllColumnIdentities =:= Identity1 with Identity2 with Identity3
     ): SchemaValidity[F, (A1, A2, A3), ColsRepr, AllColumnIdentities] =
       new SchemaValidity[F, (A1, A2, A3), ColsRepr, AllColumnIdentities] {}
 
@@ -69,7 +69,7 @@ trait InsertModule { self: ExprModule with TableModule with SelectModule =>
       ev1: Schema[(A1, A2, A3, A4)],
       ev2: ColsRepr <:< (A1, (A2, (A3, (A4, Unit)))),
       ev3: F <:< Features.Union[Features.Union[Features.Union[Features.Source[Identity1], Features.Source[Identity2]], Features.Source[Identity3]], Features.Source[Identity4]],
-      ev4: AllColumnIdentities <:< Identity1 with Identity2 with Identity3 with Identity4
+      ev4: AllColumnIdentities =:= Identity1 with Identity2 with Identity3 with Identity4
     ): SchemaValidity[F, (A1, A2, A3, A4), ColsRepr, AllColumnIdentities] =
       new SchemaValidity[F, (A1, A2, A3, A4), ColsRepr, AllColumnIdentities] {}
 
@@ -78,7 +78,7 @@ trait InsertModule { self: ExprModule with TableModule with SelectModule =>
         ev1: Schema[(A1, A2, A3, A4, A5)],
         ev2: ColsRepr <:< (A1, (A2, (A3, (A4, (A5, Unit))))),
         ev3: F <:< Features.Union[Features.Union[Features.Union[Features.Union[Features.Source[Identity1], Features.Source[Identity2]], Features.Source[Identity3]], Features.Source[Identity4]],  Features.Source[Identity5]],
-        ev4: AllColumnIdentities <:< Identity1 with Identity2 with Identity3 with Identity4 with Identity5
+        ev4: AllColumnIdentities =:= Identity1 with Identity2 with Identity3 with Identity4 with Identity5
       ): SchemaValidity[F, (A1, A2, A3, A4, A5), ColsRepr, AllColumnIdentities] =
         new SchemaValidity[F, (A1, A2, A3, A4, A5), ColsRepr, AllColumnIdentities] {}
 
@@ -87,7 +87,7 @@ trait InsertModule { self: ExprModule with TableModule with SelectModule =>
         ev1: Schema[(A1, A2, A3, A4, A5, A6)],
         ev2: ColsRepr <:< (A1, (A2, (A3, (A4, (A5, (A6, Unit)))))),
         ev3: F <:< Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Source[Identity1], Features.Source[Identity2]], Features.Source[Identity3]], Features.Source[Identity4]],  Features.Source[Identity5]], Features.Source[Identity6]],
-        ev4: AllColumnIdentities <:< Identity1 with Identity2 with Identity3 with Identity4 with Identity5 with Identity6
+        ev4: AllColumnIdentities =:= Identity1 with Identity2 with Identity3 with Identity4 with Identity5 with Identity6
       ): SchemaValidity[F, (A1, A2, A3, A4, A5, A6), ColsRepr, AllColumnIdentities] =
         new SchemaValidity[F, (A1, A2, A3, A4, A5, A6), ColsRepr, AllColumnIdentities] {}
 
@@ -96,7 +96,7 @@ trait InsertModule { self: ExprModule with TableModule with SelectModule =>
         ev1: Schema[(A1, A2, A3, A4, A5, A6, A7)],
         ev2: ColsRepr <:< (A1, (A2, (A3, (A4, (A5, (A6, (A7, Unit))))))),
         ev3: F <:< Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Source[Identity1], Features.Source[Identity2]], Features.Source[Identity3]], Features.Source[Identity4]],  Features.Source[Identity5]], Features.Source[Identity6]], Features.Source[Identity7]],
-        ev4: AllColumnIdentities <:< Identity1 with Identity2 with Identity3 with Identity4 with Identity5 with Identity6 with Identity7
+        ev4: AllColumnIdentities =:= Identity1 with Identity2 with Identity3 with Identity4 with Identity5 with Identity6 with Identity7
       ): SchemaValidity[F, (A1, A2, A3, A4, A5, A6, A7), ColsRepr, AllColumnIdentities] =
         new SchemaValidity[F, (A1, A2, A3, A4, A5, A6, A7), ColsRepr, AllColumnIdentities] {}
 
@@ -105,7 +105,7 @@ trait InsertModule { self: ExprModule with TableModule with SelectModule =>
         ev1: Schema[(A1, A2, A3, A4, A5, A6, A7, A8)],
         ev2: ColsRepr <:< (A1, (A2, (A3, (A4, (A5, (A6, (A7, (A8, Unit)))))))),
         ev3: F <:< Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Source[Identity1], Features.Source[Identity2]], Features.Source[Identity3]], Features.Source[Identity4]],  Features.Source[Identity5]], Features.Source[Identity6]], Features.Source[Identity7]], Features.Source[Identity8]],
-        ev4: AllColumnIdentities <:< Identity1 with Identity2 with Identity3 with Identity4 with Identity5 with Identity6 with Identity7 with Identity8
+        ev4: AllColumnIdentities =:= Identity1 with Identity2 with Identity3 with Identity4 with Identity5 with Identity6 with Identity7 with Identity8
       ): SchemaValidity[F, (A1, A2, A3, A4, A5, A6, A7, A8), ColsRepr, AllColumnIdentities] =
         new SchemaValidity[F, (A1, A2, A3, A4, A5, A6, A7, A8), ColsRepr, AllColumnIdentities] {}
   
@@ -114,7 +114,7 @@ trait InsertModule { self: ExprModule with TableModule with SelectModule =>
         ev1: Schema[(A1, A2, A3, A4, A5, A6, A7, A8, A9)],
         ev2: ColsRepr <:< (A1, (A2, (A3, (A4, (A5, (A6, (A7, (A8, (A9, Unit))))))))),
         ev3: F <:< Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Source[Identity1], Features.Source[Identity2]], Features.Source[Identity3]], Features.Source[Identity4]],  Features.Source[Identity5]], Features.Source[Identity6]], Features.Source[Identity7]], Features.Source[Identity8]], Features.Source[Identity9]],
-        ev4: AllColumnIdentities <:< Identity1 with Identity2 with Identity3 with Identity4 with Identity5 with Identity6 with Identity7 with Identity8 with Identity9
+        ev4: AllColumnIdentities =:= Identity1 with Identity2 with Identity3 with Identity4 with Identity5 with Identity6 with Identity7 with Identity8 with Identity9
       ): SchemaValidity[F, (A1, A2, A3, A4, A5, A6, A7, A8, A9), ColsRepr, AllColumnIdentities] =
         new SchemaValidity[F, (A1, A2, A3, A4, A5, A6, A7, A8, A9), ColsRepr, AllColumnIdentities] {}
 
@@ -123,7 +123,7 @@ trait InsertModule { self: ExprModule with TableModule with SelectModule =>
         ev1: Schema[(A1, A2, A3, A4, A5, A6, A7, A8, A9, A10)],
         ev2: ColsRepr <:< (A1, (A2, (A3, (A4, (A5, (A6, (A7, (A8, (A9, (A10, Unit)))))))))),
         ev3: F <:< Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Source[Identity1], Features.Source[Identity2]], Features.Source[Identity3]], Features.Source[Identity4]],  Features.Source[Identity5]], Features.Source[Identity6]], Features.Source[Identity7]], Features.Source[Identity8]], Features.Source[Identity9]], Features.Source[Identity10]],
-        ev4: AllColumnIdentities <:< Identity1 with Identity2 with Identity3 with Identity4 with Identity5 with Identity6 with Identity7 with Identity8 with Identity9 with Identity10
+        ev4: AllColumnIdentities =:= Identity1 with Identity2 with Identity3 with Identity4 with Identity5 with Identity6 with Identity7 with Identity8 with Identity9 with Identity10
       ): SchemaValidity[F, (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10), ColsRepr, AllColumnIdentities] =
         new SchemaValidity[F, (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10), ColsRepr, AllColumnIdentities] {}
 
@@ -132,7 +132,7 @@ trait InsertModule { self: ExprModule with TableModule with SelectModule =>
         ev1: Schema[(A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11)],
         ev2: ColsRepr <:< (A1, (A2, (A3, (A4, (A5, (A6, (A7, (A8, (A9, (A10, (A11, Unit))))))))))),
         ev3: F <:< Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Source[Identity1], Features.Source[Identity2]], Features.Source[Identity3]], Features.Source[Identity4]],  Features.Source[Identity5]], Features.Source[Identity6]], Features.Source[Identity7]], Features.Source[Identity8]], Features.Source[Identity9]], Features.Source[Identity10]], Features.Source[Identity11]],
-        ev4: AllColumnIdentities <:< Identity1 with Identity2 with Identity3 with Identity4 with Identity5 with Identity6 with Identity7 with Identity8 with Identity9 with Identity10 with Identity11
+        ev4: AllColumnIdentities =:= Identity1 with Identity2 with Identity3 with Identity4 with Identity5 with Identity6 with Identity7 with Identity8 with Identity9 with Identity10 with Identity11
       ): SchemaValidity[F, (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11), ColsRepr, AllColumnIdentities] =
         new SchemaValidity[F, (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11), ColsRepr, AllColumnIdentities] {}
 
@@ -141,7 +141,7 @@ trait InsertModule { self: ExprModule with TableModule with SelectModule =>
         ev1: Schema[(A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12)],
         ev2: ColsRepr <:< (A1, (A2, (A3, (A4, (A5, (A6, (A7, (A8, (A9, (A10, (A11, (A12, Unit)))))))))))),
         ev3: F <:< Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Source[Identity1], Features.Source[Identity2]], Features.Source[Identity3]], Features.Source[Identity4]],  Features.Source[Identity5]], Features.Source[Identity6]], Features.Source[Identity7]], Features.Source[Identity8]], Features.Source[Identity9]], Features.Source[Identity10]], Features.Source[Identity11]], Features.Source[Identity12]],
-        ev4: AllColumnIdentities <:< Identity1 with Identity2 with Identity3 with Identity4 with Identity5 with Identity6 with Identity7 with Identity8 with Identity9 with Identity10 with Identity11 with Identity12
+        ev4: AllColumnIdentities =:= Identity1 with Identity2 with Identity3 with Identity4 with Identity5 with Identity6 with Identity7 with Identity8 with Identity9 with Identity10 with Identity11 with Identity12
       ): SchemaValidity[F, (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12), ColsRepr, AllColumnIdentities] =
         new SchemaValidity[F, (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12), ColsRepr, AllColumnIdentities] {}
 
@@ -150,7 +150,7 @@ trait InsertModule { self: ExprModule with TableModule with SelectModule =>
         ev1: Schema[(A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13)],
         ev2: ColsRepr <:< (A1, (A2, (A3, (A4, (A5, (A6, (A7, (A8, (A9, (A10, (A11, (A12, (A13, Unit))))))))))))),
         ev3: F <:< Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Source[Identity1], Features.Source[Identity2]], Features.Source[Identity3]], Features.Source[Identity4]],  Features.Source[Identity5]], Features.Source[Identity6]], Features.Source[Identity7]], Features.Source[Identity8]], Features.Source[Identity9]], Features.Source[Identity10]], Features.Source[Identity11]], Features.Source[Identity12]], Features.Source[Identity13]],
-        ev4: AllColumnIdentities <:< Identity1 with Identity2 with Identity3 with Identity4 with Identity5 with Identity6 with Identity7 with Identity8 with Identity9 with Identity10 with Identity11 with Identity12 with Identity13
+        ev4: AllColumnIdentities =:= Identity1 with Identity2 with Identity3 with Identity4 with Identity5 with Identity6 with Identity7 with Identity8 with Identity9 with Identity10 with Identity11 with Identity12 with Identity13
       ): SchemaValidity[F, (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13), ColsRepr, AllColumnIdentities] =
         new SchemaValidity[F, (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13), ColsRepr, AllColumnIdentities] {}
 
@@ -159,7 +159,7 @@ trait InsertModule { self: ExprModule with TableModule with SelectModule =>
         ev1: Schema[(A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14)],
         ev2: ColsRepr <:< (A1, (A2, (A3, (A4, (A5, (A6, (A7, (A8, (A9, (A10, (A11, (A12, (A13, (A14, Unit)))))))))))))),
         ev3: F <:< Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Source[Identity1], Features.Source[Identity2]], Features.Source[Identity3]], Features.Source[Identity4]],  Features.Source[Identity5]], Features.Source[Identity6]], Features.Source[Identity7]], Features.Source[Identity8]], Features.Source[Identity9]], Features.Source[Identity10]], Features.Source[Identity11]], Features.Source[Identity12]], Features.Source[Identity13]], Features.Source[Identity14]],
-        ev4: AllColumnIdentities <:< Identity1 with Identity2 with Identity3 with Identity4 with Identity5 with Identity6 with Identity7 with Identity8 with Identity9 with Identity10 with Identity11 with Identity12 with Identity13 with Identity14
+        ev4: AllColumnIdentities =:= Identity1 with Identity2 with Identity3 with Identity4 with Identity5 with Identity6 with Identity7 with Identity8 with Identity9 with Identity10 with Identity11 with Identity12 with Identity13 with Identity14
       ): SchemaValidity[F, (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14), ColsRepr, AllColumnIdentities] =
         new SchemaValidity[F, (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14), ColsRepr, AllColumnIdentities] {}
 
@@ -168,7 +168,7 @@ trait InsertModule { self: ExprModule with TableModule with SelectModule =>
         ev1: Schema[(A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15)],
         ev2: ColsRepr <:< (A1, (A2, (A3, (A4, (A5, (A6, (A7, (A8, (A9, (A10, (A11, (A12, (A13, (A14, (A15, Unit))))))))))))))),
         ev3: F <:< Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Source[Identity1], Features.Source[Identity2]], Features.Source[Identity3]], Features.Source[Identity4]],  Features.Source[Identity5]], Features.Source[Identity6]], Features.Source[Identity7]], Features.Source[Identity8]], Features.Source[Identity9]], Features.Source[Identity10]], Features.Source[Identity11]], Features.Source[Identity12]], Features.Source[Identity13]], Features.Source[Identity14]], Features.Source[Identity15]],
-        ev4: AllColumnIdentities <:< Identity1 with Identity2 with Identity3 with Identity4 with Identity5 with Identity6 with Identity7 with Identity8 with Identity9 with Identity10 with Identity11 with Identity12 with Identity13 with Identity14 with Identity15
+        ev4: AllColumnIdentities =:= Identity1 with Identity2 with Identity3 with Identity4 with Identity5 with Identity6 with Identity7 with Identity8 with Identity9 with Identity10 with Identity11 with Identity12 with Identity13 with Identity14 with Identity15
       ): SchemaValidity[F, (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15), ColsRepr, AllColumnIdentities] =
         new SchemaValidity[F, (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15), ColsRepr, AllColumnIdentities] {}
 
@@ -177,7 +177,7 @@ trait InsertModule { self: ExprModule with TableModule with SelectModule =>
         ev1: Schema[(A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16)],
         ev2: ColsRepr <:< (A1, (A2, (A3, (A4, (A5, (A6, (A7, (A8, (A9, (A10, (A11, (A12, (A13, (A14, (A15, (A16, Unit)))))))))))))))),
         ev3: F <:< Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Source[Identity1], Features.Source[Identity2]], Features.Source[Identity3]], Features.Source[Identity4]],  Features.Source[Identity5]], Features.Source[Identity6]], Features.Source[Identity7]], Features.Source[Identity8]], Features.Source[Identity9]], Features.Source[Identity10]], Features.Source[Identity11]], Features.Source[Identity12]], Features.Source[Identity13]], Features.Source[Identity14]], Features.Source[Identity15]], Features.Source[Identity16]],
-        ev4: AllColumnIdentities <:< Identity1 with Identity2 with Identity3 with Identity4 with Identity5 with Identity6 with Identity7 with Identity8 with Identity9 with Identity10 with Identity11 with Identity12 with Identity13 with Identity14 with Identity15 with Identity16
+        ev4: AllColumnIdentities =:= Identity1 with Identity2 with Identity3 with Identity4 with Identity5 with Identity6 with Identity7 with Identity8 with Identity9 with Identity10 with Identity11 with Identity12 with Identity13 with Identity14 with Identity15 with Identity16
       ): SchemaValidity[F, (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16), ColsRepr, AllColumnIdentities] =
         new SchemaValidity[F, (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16), ColsRepr, AllColumnIdentities] {}
 
@@ -186,7 +186,7 @@ trait InsertModule { self: ExprModule with TableModule with SelectModule =>
         ev1: Schema[(A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17)],
         ev2: ColsRepr <:< (A1, (A2, (A3, (A4, (A5, (A6, (A7, (A8, (A9, (A10, (A11, (A12, (A13, (A14, (A15, (A16, (A17, Unit))))))))))))))))),
         ev3: F <:< Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Source[Identity1], Features.Source[Identity2]], Features.Source[Identity3]], Features.Source[Identity4]],  Features.Source[Identity5]], Features.Source[Identity6]], Features.Source[Identity7]], Features.Source[Identity8]], Features.Source[Identity9]], Features.Source[Identity10]], Features.Source[Identity11]], Features.Source[Identity12]], Features.Source[Identity13]], Features.Source[Identity14]], Features.Source[Identity15]], Features.Source[Identity16]], Features.Source[Identity17]],
-        ev4: AllColumnIdentities <:< Identity1 with Identity2 with Identity3 with Identity4 with Identity5 with Identity6 with Identity7 with Identity8 with Identity9 with Identity10 with Identity11 with Identity12 with Identity13 with Identity14 with Identity15 with Identity16 with Identity17 
+        ev4: AllColumnIdentities =:= Identity1 with Identity2 with Identity3 with Identity4 with Identity5 with Identity6 with Identity7 with Identity8 with Identity9 with Identity10 with Identity11 with Identity12 with Identity13 with Identity14 with Identity15 with Identity16 with Identity17 
       ): SchemaValidity[F, (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17), ColsRepr, AllColumnIdentities] =
         new SchemaValidity[F, (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17), ColsRepr, AllColumnIdentities] {}
 
@@ -195,7 +195,7 @@ trait InsertModule { self: ExprModule with TableModule with SelectModule =>
         ev1: Schema[(A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18)],
         ev2: ColsRepr <:< (A1, (A2, (A3, (A4, (A5, (A6, (A7, (A8, (A9, (A10, (A11, (A12, (A13, (A14, (A15, (A16, (A17, (A18, Unit)))))))))))))))))),
         ev3: F <:< Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Source[Identity1], Features.Source[Identity2]], Features.Source[Identity3]], Features.Source[Identity4]],  Features.Source[Identity5]], Features.Source[Identity6]], Features.Source[Identity7]], Features.Source[Identity8]], Features.Source[Identity9]], Features.Source[Identity10]], Features.Source[Identity11]], Features.Source[Identity12]], Features.Source[Identity13]], Features.Source[Identity14]], Features.Source[Identity15]], Features.Source[Identity16]], Features.Source[Identity17]], Features.Source[Identity18]],
-        ev4: AllColumnIdentities <:< Identity1 with Identity2 with Identity3 with Identity4 with Identity5 with Identity6 with Identity7 with Identity8 with Identity9 with Identity10 with Identity11 with Identity12 with Identity13 with Identity14 with Identity15 with Identity16 with Identity17 with Identity18
+        ev4: AllColumnIdentities =:= Identity1 with Identity2 with Identity3 with Identity4 with Identity5 with Identity6 with Identity7 with Identity8 with Identity9 with Identity10 with Identity11 with Identity12 with Identity13 with Identity14 with Identity15 with Identity16 with Identity17 with Identity18
       ): SchemaValidity[F, (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18), ColsRepr, AllColumnIdentities] =
         new SchemaValidity[F, (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18), ColsRepr, AllColumnIdentities] {}
 
@@ -204,7 +204,7 @@ trait InsertModule { self: ExprModule with TableModule with SelectModule =>
         ev1: Schema[(A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19)],
         ev2: ColsRepr <:< (A1, (A2, (A3, (A4, (A5, (A6, (A7, (A8, (A9, (A10, (A11, (A12, (A13, (A14, (A15, (A16, (A17, (A18, (A19, Unit))))))))))))))))))),
         ev3: F <:< Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Source[Identity1], Features.Source[Identity2]], Features.Source[Identity3]], Features.Source[Identity4]],  Features.Source[Identity5]], Features.Source[Identity6]], Features.Source[Identity7]], Features.Source[Identity8]], Features.Source[Identity9]], Features.Source[Identity10]], Features.Source[Identity11]], Features.Source[Identity12]], Features.Source[Identity13]], Features.Source[Identity14]], Features.Source[Identity15]], Features.Source[Identity16]], Features.Source[Identity17]], Features.Source[Identity18]], Features.Source[Identity19]],
-        ev4: AllColumnIdentities <:< Identity1 with Identity2 with Identity3 with Identity4 with Identity5 with Identity6 with Identity7 with Identity8 with Identity9 with Identity10 with Identity11 with Identity12 with Identity13 with Identity14 with Identity15 with Identity16 with Identity17 with Identity18 with Identity19
+        ev4: AllColumnIdentities =:= Identity1 with Identity2 with Identity3 with Identity4 with Identity5 with Identity6 with Identity7 with Identity8 with Identity9 with Identity10 with Identity11 with Identity12 with Identity13 with Identity14 with Identity15 with Identity16 with Identity17 with Identity18 with Identity19
       ): SchemaValidity[F, (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19), ColsRepr, AllColumnIdentities] =
         new SchemaValidity[F, (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19), ColsRepr, AllColumnIdentities] {}
     
@@ -213,7 +213,7 @@ trait InsertModule { self: ExprModule with TableModule with SelectModule =>
         ev1: Schema[(A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20)],
         ev2: ColsRepr <:< (A1, (A2, (A3, (A4, (A5, (A6, (A7, (A8, (A9, (A10, (A11, (A12, (A13, (A14, (A15, (A16, (A17, (A18, (A19, (A20, Unit)))))))))))))))))))),
         ev3: F <:< Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Source[Identity1], Features.Source[Identity2]], Features.Source[Identity3]], Features.Source[Identity4]],  Features.Source[Identity5]], Features.Source[Identity6]], Features.Source[Identity7]], Features.Source[Identity8]], Features.Source[Identity9]], Features.Source[Identity10]], Features.Source[Identity11]], Features.Source[Identity12]], Features.Source[Identity13]], Features.Source[Identity14]], Features.Source[Identity15]], Features.Source[Identity16]], Features.Source[Identity17]], Features.Source[Identity18]], Features.Source[Identity19]], Features.Source[Identity20]],
-        ev4: AllColumnIdentities <:< Identity1 with Identity2 with Identity3 with Identity4 with Identity5 with Identity6 with Identity7 with Identity8 with Identity9 with Identity10 with Identity11 with Identity12 with Identity13 with Identity14 with Identity15 with Identity16 with Identity17 with Identity18 with Identity19 with Identity20
+        ev4: AllColumnIdentities =:= Identity1 with Identity2 with Identity3 with Identity4 with Identity5 with Identity6 with Identity7 with Identity8 with Identity9 with Identity10 with Identity11 with Identity12 with Identity13 with Identity14 with Identity15 with Identity16 with Identity17 with Identity18 with Identity19 with Identity20
       ): SchemaValidity[F, (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20), ColsRepr, AllColumnIdentities] =
         new SchemaValidity[F, (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20), ColsRepr, AllColumnIdentities] {}
 
@@ -222,7 +222,7 @@ trait InsertModule { self: ExprModule with TableModule with SelectModule =>
         ev1: Schema[(A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, A21)],
         ev2: ColsRepr <:< (A1, (A2, (A3, (A4, (A5, (A6, (A7, (A8, (A9, (A10, (A11, (A12, (A13, (A14, (A15, (A16, (A17, (A18, (A19, (A20, (A21, Unit))))))))))))))))))))),
         ev3: F <:< Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Source[Identity1], Features.Source[Identity2]], Features.Source[Identity3]], Features.Source[Identity4]],  Features.Source[Identity5]], Features.Source[Identity6]], Features.Source[Identity7]], Features.Source[Identity8]], Features.Source[Identity9]], Features.Source[Identity10]], Features.Source[Identity11]], Features.Source[Identity12]], Features.Source[Identity13]], Features.Source[Identity14]], Features.Source[Identity15]], Features.Source[Identity16]], Features.Source[Identity17]], Features.Source[Identity18]], Features.Source[Identity19]], Features.Source[Identity20]], Features.Source[Identity21]],
-        ev4: AllColumnIdentities <:< Identity1 with Identity2 with Identity3 with Identity4 with Identity5 with Identity6 with Identity7 with Identity8 with Identity9 with Identity10 with Identity11 with Identity12 with Identity13 with Identity14 with Identity15 with Identity16 with Identity17 with Identity18 with Identity19 with Identity20 with Identity21
+        ev4: AllColumnIdentities =:= Identity1 with Identity2 with Identity3 with Identity4 with Identity5 with Identity6 with Identity7 with Identity8 with Identity9 with Identity10 with Identity11 with Identity12 with Identity13 with Identity14 with Identity15 with Identity16 with Identity17 with Identity18 with Identity19 with Identity20 with Identity21
       ): SchemaValidity[F, (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, A21), ColsRepr, AllColumnIdentities] =
         new SchemaValidity[F, (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, A21), ColsRepr, AllColumnIdentities] {}
 
@@ -231,7 +231,7 @@ trait InsertModule { self: ExprModule with TableModule with SelectModule =>
         ev1: Schema[(A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, A21, A22)],
         ev2: ColsRepr <:< (A1, (A2, (A3, (A4, (A5, (A6, (A7, (A8, (A9, (A10, (A11, (A12, (A13, (A14, (A15, (A16, (A17, (A18, (A19, (A20, (A21, (A22, Unit)))))))))))))))))))))),
         ev3: F <:< Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Source[Identity1], Features.Source[Identity2]], Features.Source[Identity3]], Features.Source[Identity4]],  Features.Source[Identity5]], Features.Source[Identity6]], Features.Source[Identity7]], Features.Source[Identity8]], Features.Source[Identity9]], Features.Source[Identity10]], Features.Source[Identity11]], Features.Source[Identity12]], Features.Source[Identity13]], Features.Source[Identity14]], Features.Source[Identity15]], Features.Source[Identity16]], Features.Source[Identity17]], Features.Source[Identity18]], Features.Source[Identity19]], Features.Source[Identity20]], Features.Source[Identity21]], Features.Source[Identity22]],
-        ev4: AllColumnIdentities <:< Identity1 with Identity2 with Identity3 with Identity4 with Identity5 with Identity6 with Identity7 with Identity8 with Identity9 with Identity10 with Identity11 with Identity12 with Identity13 with Identity14 with Identity15 with Identity16 with Identity17 with Identity18 with Identity19 with Identity20 with Identity21 with Identity22
+        ev4: AllColumnIdentities =:= Identity1 with Identity2 with Identity3 with Identity4 with Identity5 with Identity6 with Identity7 with Identity8 with Identity9 with Identity10 with Identity11 with Identity12 with Identity13 with Identity14 with Identity15 with Identity16 with Identity17 with Identity18 with Identity19 with Identity20 with Identity21 with Identity22
       ): SchemaValidity[F, (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, A21, A22), ColsRepr, AllColumnIdentities] =
         new SchemaValidity[F, (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, A21, A22), ColsRepr, AllColumnIdentities] {}
   }
@@ -243,7 +243,7 @@ trait InsertModule { self: ExprModule with TableModule with SelectModule =>
       ccSchema: Schema.CaseClass1[A, Z],
       ev: ColsRepr <:< (A, Unit),
       ev2: F <:< Features.Source[Identity1],
-      ev3: AllColumnIdentities <:< Identity1
+      ev3: AllColumnIdentities =:= Identity1
     ): SchemaValidity[F, Z, ColsRepr, AllColumnIdentities] =
       new SchemaValidity[F, Z, ColsRepr, AllColumnIdentities] {}
 
@@ -251,7 +251,7 @@ trait InsertModule { self: ExprModule with TableModule with SelectModule =>
       ccSchema: Schema.CaseClass2[A1, A2, Z],
       ev: ColsRepr <:< (A1, (A2, Unit)),
       ev2: F <:<  :||:[Features.Source[Identity1], Features.Source[Identity2]],
-      ev3: AllColumnIdentities <:< Identity1 with Identity2
+      ev3: AllColumnIdentities =:= Identity1 with Identity2
     ): SchemaValidity[F, Z, ColsRepr, AllColumnIdentities] =
       new SchemaValidity[F, Z, ColsRepr, AllColumnIdentities] {}
 
@@ -259,7 +259,7 @@ trait InsertModule { self: ExprModule with TableModule with SelectModule =>
       ccSchema: Schema.CaseClass3[A1, A2, A3, Z],
       ev: ColsRepr <:< (A1, (A2, (A3, Unit))),
       ev2: F <:< Features.Union[Features.Union[Features.Source[Identity1], Features.Source[Identity2]], Features.Source[Identity3]],
-      ev3: AllColumnIdentities <:< Identity1 with Identity2 with Identity3
+      ev3: AllColumnIdentities =:= Identity1 with Identity2 with Identity3
     ): SchemaValidity[F, Z, ColsRepr, AllColumnIdentities] =
       new SchemaValidity[F, Z, ColsRepr, AllColumnIdentities] {}
 
@@ -267,7 +267,7 @@ trait InsertModule { self: ExprModule with TableModule with SelectModule =>
       ccSchema: Schema.CaseClass4[A1, A2, A3, A4, Z],
       ev: ColsRepr <:< (A1, (A2, (A3, (A4, Unit)))),
       ev2: F <:< Features.Union[Features.Union[Features.Union[Features.Source[Identity1], Features.Source[Identity2]], Features.Source[Identity3]], Features.Source[Identity4]],
-      ev3: AllColumnIdentities <:< Identity1 with Identity2 with Identity3 with Identity4
+      ev3: AllColumnIdentities =:= Identity1 with Identity2 with Identity3 with Identity4
     ): SchemaValidity[F, Z, ColsRepr, AllColumnIdentities] =
       new SchemaValidity[F, Z, ColsRepr, AllColumnIdentities] {}
 
@@ -275,7 +275,7 @@ trait InsertModule { self: ExprModule with TableModule with SelectModule =>
       ccSchema: Schema.CaseClass5[A1, A2, A3, A4, A5, Z],
       ev: ColsRepr <:< (A1, (A2, (A3, (A4, (A5, Unit))))),
       ev2: F <:< Features.Union[Features.Union[Features.Union[Features.Union[Features.Source[Identity1], Features.Source[Identity2]], Features.Source[Identity3]],  Features.Source[Identity4]],  Features.Source[Identity5]],
-      ev3: AllColumnIdentities <:< Identity1 with Identity2 with Identity3 with Identity4 with Identity5
+      ev3: AllColumnIdentities =:= Identity1 with Identity2 with Identity3 with Identity4 with Identity5
     ): SchemaValidity[F, Z, ColsRepr, AllColumnIdentities] =
       new SchemaValidity[F, Z, ColsRepr, AllColumnIdentities] {}
 
@@ -283,7 +283,7 @@ trait InsertModule { self: ExprModule with TableModule with SelectModule =>
       ccSchema: Schema.CaseClass6[A1, A2, A3, A4, A5, A6, Z],
       ev: ColsRepr <:< (A1, (A2, (A3, (A4, (A5, (A6, Unit)))))),
       ev2: F <:< Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Source[Identity1], Features.Source[Identity2]], Features.Source[Identity3]], Features.Source[Identity4]],  Features.Source[Identity5]], Features.Source[Identity6]],
-      ev3: AllColumnIdentities <:< Identity1 with Identity2 with Identity3 with Identity4 with Identity5 with Identity6
+      ev3: AllColumnIdentities =:= Identity1 with Identity2 with Identity3 with Identity4 with Identity5 with Identity6
     ): SchemaValidity[F, Z, ColsRepr, AllColumnIdentities] =
       new SchemaValidity[F, Z, ColsRepr, AllColumnIdentities] {}
 
@@ -291,7 +291,7 @@ trait InsertModule { self: ExprModule with TableModule with SelectModule =>
       ccSchema: Schema.CaseClass7[A1, A2, A3, A4, A5, A6, A7, Z],
       ev: ColsRepr <:< (A1, (A2, (A3, (A4, (A5, (A6, (A7, Unit))))))),
       ev2: F <:< Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Source[Identity1], Features.Source[Identity2]], Features.Source[Identity3]], Features.Source[Identity4]],  Features.Source[Identity5]], Features.Source[Identity6]], Features.Source[Identity7]],
-      ev3: AllColumnIdentities <:< Identity1 with Identity2 with Identity3 with Identity4 with Identity5 with Identity6 with Identity7
+      ev3: AllColumnIdentities =:= Identity1 with Identity2 with Identity3 with Identity4 with Identity5 with Identity6 with Identity7
     ): SchemaValidity[F, Z, ColsRepr, AllColumnIdentities] =
       new SchemaValidity[F, Z, ColsRepr, AllColumnIdentities] {}
 
@@ -299,7 +299,7 @@ trait InsertModule { self: ExprModule with TableModule with SelectModule =>
       ccSchema: Schema.CaseClass8[A1, A2, A3, A4, A5, A6, A7, A8, Z],
       ev: ColsRepr <:< (A1, (A2, (A3, (A4, (A5, (A6, (A7, (A8, Unit)))))))),
       ev2: F <:< Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Source[Identity1], Features.Source[Identity2]], Features.Source[Identity3]], Features.Source[Identity4]],  Features.Source[Identity5]], Features.Source[Identity6]], Features.Source[Identity7]], Features.Source[Identity8]],
-      ev3: AllColumnIdentities <:< Identity1 with Identity2 with Identity3 with Identity4 with Identity5 with Identity6 with Identity7 with Identity8
+      ev3: AllColumnIdentities =:= Identity1 with Identity2 with Identity3 with Identity4 with Identity5 with Identity6 with Identity7 with Identity8
     ): SchemaValidity[F, Z, ColsRepr, AllColumnIdentities] =
       new SchemaValidity[F, Z, ColsRepr, AllColumnIdentities] {}
 
@@ -307,7 +307,7 @@ trait InsertModule { self: ExprModule with TableModule with SelectModule =>
       ccSchema: Schema.CaseClass9[A1, A2, A3, A4, A5, A6, A7, A8, A9, Z],
       ev: ColsRepr <:< (A1, (A2, (A3, (A4, (A5, (A6, (A7, (A8, (A9, Unit))))))))),
       ev2: F <:< Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Source[Identity1], Features.Source[Identity2]], Features.Source[Identity3]], Features.Source[Identity4]],  Features.Source[Identity5]], Features.Source[Identity6]], Features.Source[Identity7]], Features.Source[Identity8]], Features.Source[Identity9]],
-      ev3: AllColumnIdentities <:< Identity1 with Identity2 with Identity3 with Identity4 with Identity5 with Identity6 with Identity7 with Identity8 with Identity9
+      ev3: AllColumnIdentities =:= Identity1 with Identity2 with Identity3 with Identity4 with Identity5 with Identity6 with Identity7 with Identity8 with Identity9
     ): SchemaValidity[F, Z, ColsRepr, AllColumnIdentities] =
       new SchemaValidity[F, Z, ColsRepr, AllColumnIdentities] {}
 
@@ -315,7 +315,7 @@ trait InsertModule { self: ExprModule with TableModule with SelectModule =>
       ccSchema: Schema.CaseClass10[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, Z],
       ev: ColsRepr <:< (A1, (A2, (A3, (A4, (A5, (A6, (A7, (A8, (A9, (A10, Unit)))))))))),
       ev2: F <:< Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Source[Identity1], Features.Source[Identity2]], Features.Source[Identity3]], Features.Source[Identity4]],  Features.Source[Identity5]], Features.Source[Identity6]], Features.Source[Identity7]], Features.Source[Identity8]], Features.Source[Identity9]], Features.Source[Identity10]],
-      ev3: AllColumnIdentities <:< Identity1 with Identity2 with Identity3 with Identity4 with Identity5 with Identity6 with Identity7 with Identity8 with Identity9 with Identity10
+      ev3: AllColumnIdentities =:= Identity1 with Identity2 with Identity3 with Identity4 with Identity5 with Identity6 with Identity7 with Identity8 with Identity9 with Identity10
     ): SchemaValidity[F, Z, ColsRepr, AllColumnIdentities] =
       new SchemaValidity[F, Z, ColsRepr, AllColumnIdentities] {}
 
@@ -324,7 +324,7 @@ trait InsertModule { self: ExprModule with TableModule with SelectModule =>
       ccSchema: Schema.CaseClass11[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, Z],
       ev: ColsRepr <:< (A1, (A2, (A3, (A4, (A5, (A6, (A7, (A8, (A9, (A10, (A11, Unit))))))))))),
       ev2: F <:< Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Source[Identity1], Features.Source[Identity2]], Features.Source[Identity3]], Features.Source[Identity4]],  Features.Source[Identity5]], Features.Source[Identity6]], Features.Source[Identity7]], Features.Source[Identity8]], Features.Source[Identity9]], Features.Source[Identity10]], Features.Source[Identity11]],
-      ev3: AllColumnIdentities <:< Identity1 with Identity2 with Identity3 with Identity4 with Identity5 with Identity6 with Identity7 with Identity8 with Identity9 with Identity10 with Identity11 
+      ev3: AllColumnIdentities =:= Identity1 with Identity2 with Identity3 with Identity4 with Identity5 with Identity6 with Identity7 with Identity8 with Identity9 with Identity10 with Identity11 
     ): SchemaValidity[F, Z, ColsRepr, AllColumnIdentities] =
       new SchemaValidity[F, Z, ColsRepr, AllColumnIdentities] {}
 
@@ -332,7 +332,7 @@ trait InsertModule { self: ExprModule with TableModule with SelectModule =>
       ccSchema: Schema.CaseClass12[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, Z],
       ev: ColsRepr <:< (A1, (A2, (A3, (A4, (A5, (A6, (A7, (A8, (A9, (A10, (A11, (A12, Unit)))))))))))),
       ev2: F <:< Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Source[Identity1], Features.Source[Identity2]], Features.Source[Identity3]], Features.Source[Identity4]],  Features.Source[Identity5]], Features.Source[Identity6]], Features.Source[Identity7]], Features.Source[Identity8]], Features.Source[Identity9]], Features.Source[Identity10]], Features.Source[Identity11]], Features.Source[Identity12]],
-      ev3: AllColumnIdentities <:< Identity1 with Identity2 with Identity3 with Identity4 with Identity5 with Identity6 with Identity7 with Identity8 with Identity9 with Identity10 with Identity11 with Identity12 
+      ev3: AllColumnIdentities =:= Identity1 with Identity2 with Identity3 with Identity4 with Identity5 with Identity6 with Identity7 with Identity8 with Identity9 with Identity10 with Identity11 with Identity12 
     ): SchemaValidity[F, Z, ColsRepr, AllColumnIdentities] =
       new SchemaValidity[F, Z, ColsRepr, AllColumnIdentities] {}
 
@@ -340,7 +340,7 @@ trait InsertModule { self: ExprModule with TableModule with SelectModule =>
       ccSchema: Schema.CaseClass13[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, Z],
       ev: ColsRepr <:< (A1, (A2, (A3, (A4, (A5, (A6, (A7, (A8, (A9, (A10, (A11, (A12, (A13, Unit))))))))))))),
       ev2: F <:< Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Source[Identity1], Features.Source[Identity2]], Features.Source[Identity3]], Features.Source[Identity4]],  Features.Source[Identity5]], Features.Source[Identity6]], Features.Source[Identity7]], Features.Source[Identity8]], Features.Source[Identity9]], Features.Source[Identity10]], Features.Source[Identity11]], Features.Source[Identity12]], Features.Source[Identity13]], 
-      ev3: AllColumnIdentities <:< Identity1 with Identity2 with Identity3 with Identity4 with Identity5 with Identity6 with Identity7 with Identity8 with Identity9 with Identity10 with Identity11 with Identity12 with Identity13
+      ev3: AllColumnIdentities =:= Identity1 with Identity2 with Identity3 with Identity4 with Identity5 with Identity6 with Identity7 with Identity8 with Identity9 with Identity10 with Identity11 with Identity12 with Identity13
     ): SchemaValidity[F, Z, ColsRepr, AllColumnIdentities] =
       new SchemaValidity[F, Z, ColsRepr, AllColumnIdentities] {}
 
@@ -348,7 +348,7 @@ trait InsertModule { self: ExprModule with TableModule with SelectModule =>
       ccSchema: Schema.CaseClass14[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, Z],
       ev: ColsRepr <:< (A1, (A2, (A3, (A4, (A5, (A6, (A7, (A8, (A9, (A10, (A11, (A12, (A13, (A14, Unit)))))))))))))),
       ev2: F <:< Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Source[Identity1], Features.Source[Identity2]], Features.Source[Identity3]], Features.Source[Identity4]],  Features.Source[Identity5]], Features.Source[Identity6]], Features.Source[Identity7]], Features.Source[Identity8]], Features.Source[Identity9]], Features.Source[Identity10]], Features.Source[Identity11]], Features.Source[Identity12]], Features.Source[Identity13]], Features.Source[Identity14]],
-      ev3: AllColumnIdentities <:< Identity1 with Identity2 with Identity3 with Identity4 with Identity5 with Identity6 with Identity7 with Identity8 with Identity9 with Identity10 with Identity11 with Identity12 with Identity13 with Identity14
+      ev3: AllColumnIdentities =:= Identity1 with Identity2 with Identity3 with Identity4 with Identity5 with Identity6 with Identity7 with Identity8 with Identity9 with Identity10 with Identity11 with Identity12 with Identity13 with Identity14
     ): SchemaValidity[F, Z, ColsRepr, AllColumnIdentities] =
       new SchemaValidity[F, Z, ColsRepr, AllColumnIdentities] {}
 
@@ -359,7 +359,7 @@ trait InsertModule { self: ExprModule with TableModule with SelectModule =>
         (A2, (A3, (A4, (A5, (A6, (A7, (A8, (A9, (A10, (A11, (A12, (A13, (A14, (A15, Unit))))))))))))))
       ),
       ev2: F <:< Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Source[Identity1], Features.Source[Identity2]], Features.Source[Identity3]], Features.Source[Identity4]],  Features.Source[Identity5]], Features.Source[Identity6]], Features.Source[Identity7]], Features.Source[Identity8]], Features.Source[Identity9]], Features.Source[Identity10]], Features.Source[Identity11]], Features.Source[Identity12]], Features.Source[Identity13]], Features.Source[Identity14]], Features.Source[Identity15]],
-      ev3: AllColumnIdentities <:< Identity1 with Identity2 with Identity3 with Identity4 with Identity5 with Identity6 with Identity7 with Identity8 with Identity9 with Identity10 with Identity11 with Identity12 with Identity13 with Identity14 with Identity15
+      ev3: AllColumnIdentities =:= Identity1 with Identity2 with Identity3 with Identity4 with Identity5 with Identity6 with Identity7 with Identity8 with Identity9 with Identity10 with Identity11 with Identity12 with Identity13 with Identity14 with Identity15
     ): SchemaValidity[F, Z, ColsRepr, AllColumnIdentities] =
       new SchemaValidity[F, Z, ColsRepr, AllColumnIdentities] {}
 
@@ -371,7 +371,7 @@ trait InsertModule { self: ExprModule with TableModule with SelectModule =>
         (A2, (A3, (A4, (A5, (A6, (A7, (A8, (A9, (A10, (A11, (A12, (A13, (A14, (A15, (A16, Unit)))))))))))))))
       ),
       ev2: F <:< Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Source[Identity1], Features.Source[Identity2]], Features.Source[Identity3]], Features.Source[Identity4]],  Features.Source[Identity5]], Features.Source[Identity6]], Features.Source[Identity7]], Features.Source[Identity8]], Features.Source[Identity9]], Features.Source[Identity10]], Features.Source[Identity11]], Features.Source[Identity12]], Features.Source[Identity13]], Features.Source[Identity14]], Features.Source[Identity15]], Features.Source[Identity16]],
-      ev3: AllColumnIdentities <:< Identity1 with Identity2 with Identity3 with Identity4 with Identity5 with Identity6 with Identity7 with Identity8 with Identity9 with Identity10 with Identity11 with Identity12 with Identity13 with Identity14 with Identity15 with Identity16
+      ev3: AllColumnIdentities =:= Identity1 with Identity2 with Identity3 with Identity4 with Identity5 with Identity6 with Identity7 with Identity8 with Identity9 with Identity10 with Identity11 with Identity12 with Identity13 with Identity14 with Identity15 with Identity16
     ): SchemaValidity[F, Z, ColsRepr, AllColumnIdentities] =
       new SchemaValidity[F, Z, ColsRepr, AllColumnIdentities] {}
 
@@ -383,7 +383,7 @@ trait InsertModule { self: ExprModule with TableModule with SelectModule =>
         (A2, (A3, (A4, (A5, (A6, (A7, (A8, (A9, (A10, (A11, (A12, (A13, (A14, (A15, (A16, (A17, Unit))))))))))))))))
       ),
       ev2: F <:< Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Source[Identity1], Features.Source[Identity2]], Features.Source[Identity3]], Features.Source[Identity4]],  Features.Source[Identity5]], Features.Source[Identity6]], Features.Source[Identity7]], Features.Source[Identity8]], Features.Source[Identity9]], Features.Source[Identity10]], Features.Source[Identity11]], Features.Source[Identity12]], Features.Source[Identity13]], Features.Source[Identity14]], Features.Source[Identity15]], Features.Source[Identity16]], Features.Source[Identity17]],
-      ev3: AllColumnIdentities <:< Identity1 with Identity2 with Identity3 with Identity4 with Identity5 with Identity6 with Identity7 with Identity8 with Identity9 with Identity10 with Identity11 with Identity12 with Identity13 with Identity14 with Identity15 with Identity16 with Identity17
+      ev3: AllColumnIdentities =:= Identity1 with Identity2 with Identity3 with Identity4 with Identity5 with Identity6 with Identity7 with Identity8 with Identity9 with Identity10 with Identity11 with Identity12 with Identity13 with Identity14 with Identity15 with Identity16 with Identity17
     ): SchemaValidity[F, Z, ColsRepr, AllColumnIdentities] =
       new SchemaValidity[F, Z, ColsRepr, AllColumnIdentities] {}
 
@@ -399,7 +399,7 @@ trait InsertModule { self: ExprModule with TableModule with SelectModule =>
         )
       ),
       ev2: F <:< Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Source[Identity1], Features.Source[Identity2]], Features.Source[Identity3]], Features.Source[Identity4]],  Features.Source[Identity5]], Features.Source[Identity6]], Features.Source[Identity7]], Features.Source[Identity8]], Features.Source[Identity9]], Features.Source[Identity10]], Features.Source[Identity11]], Features.Source[Identity12]], Features.Source[Identity13]], Features.Source[Identity14]], Features.Source[Identity15]], Features.Source[Identity16]], Features.Source[Identity17]], Features.Source[Identity18]],
-      ev3: AllColumnIdentities <:< Identity1 with Identity2 with Identity3 with Identity4 with Identity5 with Identity6 with Identity7 with Identity8 with Identity9 with Identity10 with Identity11 with Identity12 with Identity13 with Identity14 with Identity15 with Identity16 with Identity17 with Identity18
+      ev3: AllColumnIdentities =:= Identity1 with Identity2 with Identity3 with Identity4 with Identity5 with Identity6 with Identity7 with Identity8 with Identity9 with Identity10 with Identity11 with Identity12 with Identity13 with Identity14 with Identity15 with Identity16 with Identity17 with Identity18
     ): SchemaValidity[F, Z, ColsRepr, AllColumnIdentities] =
       new SchemaValidity[F, Z, ColsRepr, AllColumnIdentities] {}
 
@@ -420,7 +420,7 @@ trait InsertModule { self: ExprModule with TableModule with SelectModule =>
           )
         )
       ),
-      ev2: F <:< Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Source[Identity1], Features.Source[Identity2]], Features.Source[Identity3]], Features.Source[Identity4]],  Features.Source[Identity5]], Features.Source[Identity6]], Features.Source[Identity7]], Features.Source[Identity8]], Features.Source[Identity9]], Features.Source[Identity10]], Features.Source[Identity11]], Features.Source[Identity12]], Features.Source[Identity13]], Features.Source[Identity14]], Features.Source[Identity15]], Features.Source[Identity16]], Features.Source[Identity17]], Features.Source[Identity18]], Features.Source[Identity19]],
+      ev2: F =:= Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Source[Identity1], Features.Source[Identity2]], Features.Source[Identity3]], Features.Source[Identity4]],  Features.Source[Identity5]], Features.Source[Identity6]], Features.Source[Identity7]], Features.Source[Identity8]], Features.Source[Identity9]], Features.Source[Identity10]], Features.Source[Identity11]], Features.Source[Identity12]], Features.Source[Identity13]], Features.Source[Identity14]], Features.Source[Identity15]], Features.Source[Identity16]], Features.Source[Identity17]], Features.Source[Identity18]], Features.Source[Identity19]],
       ev3: AllColumnIdentities <:< Identity1 with Identity2 with Identity3 with Identity4 with Identity5 with Identity6 with Identity7 with Identity8 with Identity9 with Identity10 with Identity11 with Identity12 with Identity13 with Identity14 with Identity15 with Identity16 with Identity17 with Identity18 with Identity19
     ): SchemaValidity[F, Z, ColsRepr, AllColumnIdentities] =
       new SchemaValidity[F, Z, ColsRepr, AllColumnIdentities] {}
@@ -448,7 +448,7 @@ trait InsertModule { self: ExprModule with TableModule with SelectModule =>
           )
         )
       ),
-      ev2: F <:< Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Source[Identity1], Features.Source[Identity2]], Features.Source[Identity3]], Features.Source[Identity4]],  Features.Source[Identity5]], Features.Source[Identity6]], Features.Source[Identity7]], Features.Source[Identity8]], Features.Source[Identity9]], Features.Source[Identity10]], Features.Source[Identity11]], Features.Source[Identity12]], Features.Source[Identity13]], Features.Source[Identity14]], Features.Source[Identity15]], Features.Source[Identity16]], Features.Source[Identity17]], Features.Source[Identity18]], Features.Source[Identity19]], Features.Source[Identity20]],
+      ev2: F =:= Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Source[Identity1], Features.Source[Identity2]], Features.Source[Identity3]], Features.Source[Identity4]],  Features.Source[Identity5]], Features.Source[Identity6]], Features.Source[Identity7]], Features.Source[Identity8]], Features.Source[Identity9]], Features.Source[Identity10]], Features.Source[Identity11]], Features.Source[Identity12]], Features.Source[Identity13]], Features.Source[Identity14]], Features.Source[Identity15]], Features.Source[Identity16]], Features.Source[Identity17]], Features.Source[Identity18]], Features.Source[Identity19]], Features.Source[Identity20]],
       ev3: AllColumnIdentities <:< Identity1 with Identity2 with Identity3 with Identity4 with Identity5 with Identity6 with Identity7 with Identity8 with Identity9 with Identity10 with Identity11 with Identity12 with Identity13 with Identity14 with Identity15 with Identity16 with Identity17 with Identity18 with Identity19 with Identity20
     ): SchemaValidity[F, Z, ColsRepr, AllColumnIdentities] =
       new SchemaValidity[F, Z, ColsRepr, AllColumnIdentities] {}
@@ -478,7 +478,7 @@ trait InsertModule { self: ExprModule with TableModule with SelectModule =>
           )
         )
       ),
-      ev2: F <:< Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Source[Identity1], Features.Source[Identity2]], Features.Source[Identity3]], Features.Source[Identity4]],  Features.Source[Identity5]], Features.Source[Identity6]], Features.Source[Identity7]], Features.Source[Identity8]], Features.Source[Identity9]], Features.Source[Identity10]], Features.Source[Identity11]], Features.Source[Identity12]], Features.Source[Identity13]], Features.Source[Identity14]], Features.Source[Identity15]], Features.Source[Identity16]], Features.Source[Identity17]], Features.Source[Identity18]], Features.Source[Identity19]], Features.Source[Identity20]], Features.Source[Identity21]], 
+      ev2: F =:= Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Source[Identity1], Features.Source[Identity2]], Features.Source[Identity3]], Features.Source[Identity4]],  Features.Source[Identity5]], Features.Source[Identity6]], Features.Source[Identity7]], Features.Source[Identity8]], Features.Source[Identity9]], Features.Source[Identity10]], Features.Source[Identity11]], Features.Source[Identity12]], Features.Source[Identity13]], Features.Source[Identity14]], Features.Source[Identity15]], Features.Source[Identity16]], Features.Source[Identity17]], Features.Source[Identity18]], Features.Source[Identity19]], Features.Source[Identity20]], Features.Source[Identity21]], 
       ev3: AllColumnIdentities <:< Identity1 with Identity2 with Identity3 with Identity4 with Identity5 with Identity6 with Identity7 with Identity8 with Identity9 with Identity10 with Identity11 with Identity12 with Identity13 with Identity14 with Identity15 with Identity16 with Identity17 with Identity18 with Identity19 with Identity20 with Identity21
     ): SchemaValidity[F, Z, ColsRepr, AllColumnIdentities] =
       new SchemaValidity[F, Z, ColsRepr, AllColumnIdentities] {}
@@ -514,7 +514,7 @@ trait InsertModule { self: ExprModule with TableModule with SelectModule =>
           )
         )
       ),
-      ev2: F <:< Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Source[Identity1], Features.Source[Identity2]], Features.Source[Identity3]], Features.Source[Identity4]],  Features.Source[Identity5]], Features.Source[Identity6]], Features.Source[Identity7]], Features.Source[Identity8]], Features.Source[Identity9]], Features.Source[Identity10]], Features.Source[Identity11]], Features.Source[Identity12]], Features.Source[Identity13]], Features.Source[Identity14]], Features.Source[Identity15]], Features.Source[Identity16]], Features.Source[Identity17]], Features.Source[Identity18]], Features.Source[Identity19]], Features.Source[Identity20]], Features.Source[Identity21]], Features.Source[Identity22]],
+      ev2: F =:= Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Union[Features.Source[Identity1], Features.Source[Identity2]], Features.Source[Identity3]], Features.Source[Identity4]],  Features.Source[Identity5]], Features.Source[Identity6]], Features.Source[Identity7]], Features.Source[Identity8]], Features.Source[Identity9]], Features.Source[Identity10]], Features.Source[Identity11]], Features.Source[Identity12]], Features.Source[Identity13]], Features.Source[Identity14]], Features.Source[Identity15]], Features.Source[Identity16]], Features.Source[Identity17]], Features.Source[Identity18]], Features.Source[Identity19]], Features.Source[Identity20]], Features.Source[Identity21]], Features.Source[Identity22]],
       ev3: AllColumnIdentities <:< Identity1 with Identity2 with Identity3 with Identity4 with Identity5 with Identity6 with Identity7 with Identity8 with Identity9 with Identity10 with Identity11 with Identity12 with Identity13 with Identity14 with Identity15 with Identity16 with Identity17 with Identity18 with Identity19 with Identity20 with Identity21 with Identity22
     ): SchemaValidity[F, Z, ColsRepr, AllColumnIdentities] =
       new SchemaValidity[F, Z, ColsRepr, AllColumnIdentities] {}

--- a/core/jvm/src/main/scala/zio/sql/select.scala
+++ b/core/jvm/src/main/scala/zio/sql/select.scala
@@ -338,6 +338,7 @@ trait SelectModule { self: ExprModule with TableModule =>
       ): Subselect[F, Repr, Source, Subsource, Head, Tail] =
         copy(orderByExprs = self.orderByExprs ++ (o :: os.toList))
 
+      // how about two havings ?
       def having[F2: Features.IsFullyAggregated](havingExpr2: Expr[F2, Source, Boolean])
         : Subselect[F, Repr, Source, Subsource, Head, Tail] =
         copy(havingExpr = self.havingExpr && havingExpr2)

--- a/core/jvm/src/main/scala/zio/sql/select.scala
+++ b/core/jvm/src/main/scala/zio/sql/select.scala
@@ -323,8 +323,7 @@ trait SelectModule { self: ExprModule with TableModule =>
       limit: Option[Long] = None
     ) extends Read[Repr] { self =>
 
-      //def where[F2: Features.IsNotAggregated](
-      def where[F2](
+      def where[F2: Features.IsNotAggregated](
         whereExpr2: Expr[F2, Source, Boolean]
       ): Subselect[F, Repr, Source, Subsource, Head, Tail] =
         copy(whereExpr = self.whereExpr && whereExpr2)
@@ -339,24 +338,18 @@ trait SelectModule { self: ExprModule with TableModule =>
       ): Subselect[F, Repr, Source, Subsource, Head, Tail] =
         copy(orderByExprs = self.orderByExprs ++ (o :: os.toList))
 
-      /**
-       * TODO
-       *
-       * need to restrict varargs _ : IsAggregated
-       */
-      def having(havingExpr2: Expr[_, Source, Boolean])
-      //(implicit ev: Features.IsFullyAggregated[F])
+      def having[F2: Features.IsFullyAggregated](havingExpr2: Expr[F2, Source, Boolean])
         : Subselect[F, Repr, Source, Subsource, Head, Tail] =
-        // val _ = ev
         copy(havingExpr = self.havingExpr && havingExpr2)
 
       /**
-       *         TODO support
+       *         TODO 
+       *  allow
        *         select(fkCustomerId)
        *          .from(orders)
        *          .groupBy(fkCustomerId)
        *
-       *          DONT allow
+       *   don't  allow
        *          select(Count(orderId) ++ Count(orderId))
        *          .from(orders)
        *          .groupBy(Count(orderId))

--- a/core/jvm/src/main/scala/zio/sql/select.scala
+++ b/core/jvm/src/main/scala/zio/sql/select.scala
@@ -2,7 +2,7 @@ package zio.sql
 
 import scala.language.implicitConversions
 
-trait SelectModule { self: ExprModule with TableModule =>
+trait SelectModule { self: ExprModule with TableModule with UtilsModule =>
 
   sealed case class Selector[F, Source, B <: SelectionSet[Source], Unaggregated](selection: Selection[F, Source, B])
 
@@ -31,10 +31,11 @@ trait SelectModule { self: ExprModule with TableModule =>
         Source,
         selectBuilder.selection.value.ColumnHead,
         selectBuilder.selection.value.SelectionTail
-      ]
+      ],
+      normalizer: TrailingUnitNormalizer[selectBuilder.selection.value.ResultTypeRepr]
     ): Read.Select[
       F,
-      selectBuilder.selection.value.ResultTypeRepr,
+      normalizer.Out,
       Source,
       selectBuilder.selection.value.ColumnHead,
       selectBuilder.selection.value.SelectionTail
@@ -47,7 +48,7 @@ trait SelectModule { self: ExprModule with TableModule =>
       ]
       val b: B0 = selectBuilder.selection.value.asInstanceOf[B0]
 
-      Read.Subselect(Selection[F, Source, B0](b), None, true)//.normalize
+      Read.Subselect(Selection[F, Source, B0](b), None, true).normalize
     }
   }
 
@@ -56,10 +57,11 @@ trait SelectModule { self: ExprModule with TableModule =>
   ) {
 
     def from[Source0 <: Source](table: Table.Aux[Source0])(implicit
-      ev: B <:< SelectionSet.Cons[Source0, selection.value.ColumnHead, selection.value.SelectionTail]
+      ev: B <:< SelectionSet.Cons[Source0, selection.value.ColumnHead, selection.value.SelectionTail],
+      normalizer: TrailingUnitNormalizer[selection.value.ResultTypeRepr]
     ): AggSelectBuilderGroupBy[
       F0,
-      selection.value.ResultTypeRepr,
+      normalizer.Out,
       Source0,
       selection.value.ColumnHead,
       selection.value.SelectionTail,
@@ -75,12 +77,12 @@ trait SelectModule { self: ExprModule with TableModule =>
 
       AggSelectBuilderGroupBy[
         F0,
-        selection.value.ResultTypeRepr,
+        normalizer.Out,
         Source0,
         selection.value.ColumnHead,
         selection.value.SelectionTail,
         Unaggregated
-      ](Read.Subselect(Selection[F0, Source0, B0](b), Some(table), true))
+      ](Read.Subselect(Selection[F0, Source0, B0](b), Some(table), true).normalize)
     }
   }
 
@@ -206,10 +208,11 @@ trait SelectModule { self: ExprModule with TableModule =>
   sealed case class SelectBuilder[F0, Source, B <: SelectionSet[Source]](selection: Selection[F0, Source, B]) {
 
     def from[Source0 <: Source](table: Table.Aux[Source0])(implicit
-      ev: B <:< SelectionSet.Cons[Source0, selection.value.ColumnHead, selection.value.SelectionTail]
+      ev: B <:< SelectionSet.Cons[Source0, selection.value.ColumnHead, selection.value.SelectionTail],
+      normalizer : TrailingUnitNormalizer[selection.value.ResultTypeRepr]
     ): Read.Select[
       F0,
-      selection.value.ResultTypeRepr,
+      normalizer.Out,
       Source0,
       selection.value.ColumnHead,
       selection.value.SelectionTail
@@ -222,7 +225,7 @@ trait SelectModule { self: ExprModule with TableModule =>
       ]
       val b: B0 = selection.value.asInstanceOf[B0]
 
-      Read.Subselect(Selection[F0, Source0, B0](b), Some(table), true)
+      Read.Subselect(Selection[F0, Source0, B0](b), Some(table), true).normalize
     }
   }
 
@@ -236,10 +239,11 @@ trait SelectModule { self: ExprModule with TableModule =>
   ) {
     def from[Source0](table: Table.Aux[Source0])(implicit
       ev1: Source0 with ParentTable <:< Source,
-      ev2: B <:< SelectionSet.Cons[Source, selection.value.ColumnHead, selection.value.SelectionTail]
+      ev2: B <:< SelectionSet.Cons[Source, selection.value.ColumnHead, selection.value.SelectionTail],
+      normalizer: TrailingUnitNormalizer[selection.value.ResultTypeRepr]
     ): Read.Subselect[
       F,
-      selection.value.ResultTypeRepr,
+      normalizer.Out,
       Source with ParentTable,
       Source0,
       selection.value.ColumnHead,
@@ -253,7 +257,7 @@ trait SelectModule { self: ExprModule with TableModule =>
       ]
       val b: B0 = selection.value.asInstanceOf[B0]
 
-      Read.Subselect(Selection[F, Source with ParentTable, B0](b), Some(table), true)
+      Read.Subselect(Selection[F, Source with ParentTable, B0](b), Some(table), true).normalize
     }
   }
 
@@ -273,7 +277,20 @@ trait SelectModule { self: ExprModule with TableModule =>
 
     val columnSet: CS
 
+     /**
+     * Maps the [[Read]] query's output to another type by providing a function
+     * that can transform from the current type to the new type.
+     */
+    def map[Out2](f: Out => Out2): Read.Aux[ResultType, Out2] =
+      Read.Mapped(self, f)
+
     def asTable(name: TableName): Table.DerivedTable[Out, Read[Out]]
+
+  
+    def to[Target](f: Out => Target): Read[Target] =
+      self.map { resultType =>
+        f(resultType)
+      }
 
     //TODO use this
     def union[Out1 >: Out](that: Read.Aux[ResultType, Out1]): Read.Aux[ResultType, Out1] =
@@ -308,6 +325,23 @@ trait SelectModule { self: ExprModule with TableModule =>
 
     type Aux[ResultType0, Out] = Read[Out] {
       type ResultType = ResultType0
+    }
+
+    sealed case class Mapped[Repr, Out, Out2](read: Read.Aux[Repr, Out], f: Out => Out2) extends Read[Out2] { self =>
+      override type ResultType = Repr
+
+      override val mapper = read.mapper.andThen(f)
+
+      override type ColumnHead = read.ColumnHead
+      override type ColumnTail = read.ColumnTail
+      override type CS         = read.CS
+
+      override type HeadIdentity = read.HeadIdentity
+
+      override val columnSet: CS = read.columnSet
+
+      override def asTable(name: TableName): Table.DerivedTable[Out2, Mapped[Repr, Out, Out2]] =
+        Table.DerivedTable[Out2, Mapped[Repr, Out, Out2]](self, name)
     }
 
     type Select[F, Repr, Source, Head, Tail <: SelectionSet[Source]] = Subselect[F, Repr, Source, Source, Head, Tail]
@@ -365,6 +399,8 @@ trait SelectModule { self: ExprModule with TableModule =>
         copy(groupByExprs =
           (key :: keys.toList).foldLeft[ExprSet[Source]](ExprSet.NoExpr)((tail, head) => ExprSet.ExprCons(head, tail))
         )
+
+      def normalize(implicit instance: TrailingUnitNormalizer[ResultType]): Subselect[F, instance.Out, Source, Subsource, Head, Tail] = self.asInstanceOf[Subselect[F, instance.Out, Source, Subsource, Head, Tail]]
 
       override def asTable(
         name: TableName

--- a/core/jvm/src/main/scala/zio/sql/table.scala
+++ b/core/jvm/src/main/scala/zio/sql/table.scala
@@ -204,8 +204,9 @@ trait TableModule { self: ExprModule with SelectModule with UtilsModule =>
       new Table.JoinBuilder[self.TableType, That](JoinType.RightOuter, self, that)
 
     final val subselect: SubselectPartiallyApplied[TableType] = new SubselectPartiallyApplied[TableType]
-    
-    def columns(implicit i: TrailingUnitNormalizer[columnSet.ColumnsRepr[TableType]]): i.Out = i.apply(columnSet.makeColumns[TableType](columnToExpr))
+
+    def columns(implicit i: TrailingUnitNormalizer[columnSet.ColumnsRepr[TableType]]): i.Out =
+      i.apply(columnSet.makeColumns[TableType](columnToExpr))
 
     val columnSet: ColumnSet.Cons[ColumnHead, ColumnTail, HeadIdentity0]
 

--- a/core/jvm/src/main/scala/zio/sql/table.scala
+++ b/core/jvm/src/main/scala/zio/sql/table.scala
@@ -5,7 +5,7 @@ import zio.Chunk
 import java.time._
 import java.util.UUID
 
-trait TableModule { self: ExprModule with SelectModule =>
+trait TableModule { self: ExprModule with SelectModule with UtilsModule =>
 
   sealed trait Singleton0[A] {
     type SingletonIdentity
@@ -127,10 +127,6 @@ trait TableModule { self: ExprModule with SelectModule =>
       Cons(Column.Named[A, ColumnIdentity](name), Empty)
   }
 
-  object :*: {
-    def unapply[A, B](tuple: (A, B)): Some[(A, B)] = Some(tuple)
-  }
-
   sealed trait Column[+A] {
     type Identity
     def typeTag: TypeTag[A]
@@ -208,8 +204,8 @@ trait TableModule { self: ExprModule with SelectModule =>
       new Table.JoinBuilder[self.TableType, That](JoinType.RightOuter, self, that)
 
     final val subselect: SubselectPartiallyApplied[TableType] = new SubselectPartiallyApplied[TableType]
-
-    final def columns = columnSet.makeColumns[TableType](columnToExpr)
+    
+    def columns(implicit i: TrailingUnitNormalizer[columnSet.ColumnsRepr[TableType]]): i.Out = i.apply(columnSet.makeColumns[TableType](columnToExpr))
 
     val columnSet: ColumnSet.Cons[ColumnHead, ColumnTail, HeadIdentity0]
 

--- a/core/jvm/src/main/scala/zio/sql/typetag.scala
+++ b/core/jvm/src/main/scala/zio/sql/typetag.scala
@@ -10,7 +10,7 @@ trait TypeTagModule { self: SelectModule =>
   type TypeTagExtension[+A] <: Tag[A] with Decodable[A]
 
   trait Decodable[+A] {
-    def decode(column: Either[Int, String], resultSet: ResultSet): Either[DecodingError, A]
+    def decode(column: Int, resultSet: ResultSet): Either[DecodingError, A]
   }
 
   trait Tag[+A] {

--- a/core/jvm/src/main/scala/zio/sql/utils.scala
+++ b/core/jvm/src/main/scala/zio/sql/utils.scala
@@ -12,135 +12,223 @@ trait UtilsModule { self =>
       type Out = Out0
     }
     // format: off
-    implicit def arity1[In, A](implicit ev: In =:= (A, Unit)) : TrailingUnitNormalizer.WithOut[In, A] = new TrailingUnitNormalizer[In] {
+    //ev needs to be reversed because scala 2.12 cannot prove In =:= (A, Unit), therefore asInstanceOf
+    implicit def arity1[In, A](implicit ev: (A, Unit) =:= In) : TrailingUnitNormalizer.WithOut[In, A] = new TrailingUnitNormalizer[In] {
       override type Out = A
 
-      override def apply(in: In): A = in._1
+      override def apply(in0: In): A = {
+        val in = in0.asInstanceOf[(A, Unit)]
+
+        in._1
+      }
     }
 
-    implicit def arity2[In, A, B](implicit ev: In =:= (A, (B, Unit))) : TrailingUnitNormalizer.WithOut[In, (A, B)] = new TrailingUnitNormalizer[In] {
+    implicit def arity2[In, A, B](implicit ev: (A, (B, Unit)) =:= In) : TrailingUnitNormalizer.WithOut[In, (A, B)] = new TrailingUnitNormalizer[In] {
       override type Out = (A, B)
 
-      override def apply(in: In): Out = (in._1, in._2._1)
+      override def apply(in0: In): Out = {
+        val in = in0.asInstanceOf[(A, (B, Unit))]
+
+        (in._1, in._2._1)
+      }
     }
 
-    implicit def arity3[In, A, B, C](implicit ev: In =:= (A, (B, (C, Unit)))) : TrailingUnitNormalizer.WithOut[In, (A, B, C)] = new TrailingUnitNormalizer[In] {
+    implicit def arity3[In, A, B, C](implicit ev: (A, (B, (C, Unit))) =:= In) : TrailingUnitNormalizer.WithOut[In, (A, B, C)] = new TrailingUnitNormalizer[In] {
       override type Out = (A, B, C)
 
-      override def apply(in: In): Out = (in._1, in._2._1, in._2._2._1)
+      override def apply(in0: In): Out = {
+        val in = in0.asInstanceOf[(A, (B, (C, Unit)))]
+
+        (in._1, in._2._1, in._2._2._1)
+      }
     }
 
-    implicit def arity4[In, A, B, C, D](implicit ev: In =:= (A, (B, (C, (D, Unit))))) : TrailingUnitNormalizer.WithOut[In, (A, B, C, D)] = new TrailingUnitNormalizer[In] {
+    implicit def arity4[In, A, B, C, D](implicit ev: (A, (B, (C, (D, Unit)))) =:= In) : TrailingUnitNormalizer.WithOut[In, (A, B, C, D)] = new TrailingUnitNormalizer[In] {
       override type Out = (A, B, C, D)
 
-      override def apply(in: In): Out = (in._1, in._2._1, in._2._2._1, in._2._2._2._1)
+      override def apply(in0: In): Out = {
+        val in = in0.asInstanceOf[(A, (B, (C, (D, Unit))))]
+
+        (in._1, in._2._1, in._2._2._1, in._2._2._2._1)
+      }
     }
 
-    implicit def arity5[In, A, B, C, D, E](implicit ev: In =:= (A, (B, (C, (D, (E, Unit)))))) : TrailingUnitNormalizer.WithOut[In, (A, B, C, D, E)] = new TrailingUnitNormalizer[In] {
+    implicit def arity5[In, A, B, C, D, E](implicit ev: (A, (B, (C, (D, (E, Unit))))) =:= In) : TrailingUnitNormalizer.WithOut[In, (A, B, C, D, E)] = new TrailingUnitNormalizer[In] {
       override type Out = (A, B, C, D, E)
 
-      override def apply(in: In): Out = (in._1, in._2._1, in._2._2._1, in._2._2._2._1, in._2._2._2._2._1)
+      override def apply(in0: In): Out = {
+        val in = in0.asInstanceOf[(A, (B, (C, (D, (E, Unit)))))]
+
+        (in._1, in._2._1, in._2._2._1, in._2._2._2._1, in._2._2._2._2._1)
+      }
     }
 
-    implicit def arity6[In, A, B, C, D, E, F](implicit ev: In =:= (A, (B, (C, (D, (E, (F, Unit))))))) : TrailingUnitNormalizer.WithOut[In, (A, B, C, D, E, F)] = new TrailingUnitNormalizer[In] {
+    implicit def arity6[In, A, B, C, D, E, F](implicit ev: (A, (B, (C, (D, (E, (F, Unit)))))) =:= In) : TrailingUnitNormalizer.WithOut[In, (A, B, C, D, E, F)] = new TrailingUnitNormalizer[In] {
       override type Out = (A, B, C, D, E, F)
 
-      override def apply(in: In): Out = (in._1, in._2._1, in._2._2._1, in._2._2._2._1, in._2._2._2._2._1,  in._2._2._2._2._2._1)
+      override def apply(in0: In): Out = {
+        val in = in0.asInstanceOf[(A, (B, (C, (D, (E, (F, Unit))))))]
+
+        (in._1, in._2._1, in._2._2._1, in._2._2._2._1, in._2._2._2._2._1,  in._2._2._2._2._2._1)
+      }
     }
 
-    implicit def arity7[In, A, B, C, D, E, F, G](implicit ev: In =:= (A, (B, (C, (D, (E, (F, (G, Unit)))))))): TrailingUnitNormalizer.WithOut[In, (A, B, C, D, E, F, G)] = new TrailingUnitNormalizer[In] {
+    implicit def arity7[In, A, B, C, D, E, F, G](implicit ev: (A, (B, (C, (D, (E, (F, (G, Unit))))))) =:= In): TrailingUnitNormalizer.WithOut[In, (A, B, C, D, E, F, G)] = new TrailingUnitNormalizer[In] {
       override type Out = (A, B, C, D, E, F, G)
 
-      override def apply(in: In): Out = (in._1, in._2._1, in._2._2._1, in._2._2._2._1, in._2._2._2._2._1, in._2._2._2._2._2._1, in._2._2._2._2._2._2._1)
+      override def apply(in0: In): Out = {
+        val in = in0.asInstanceOf[(A, (B, (C, (D, (E, (F, (G, Unit)))))))]
+
+        (in._1, in._2._1, in._2._2._1, in._2._2._2._1, in._2._2._2._2._1, in._2._2._2._2._2._1, in._2._2._2._2._2._2._1)
+      }
     }
 
-    implicit def arity8[In, A, B, C, D, E, F, G, H](implicit ev: In =:= (A, (B, (C, (D, (E, (F, (G, (H, Unit))))))))): TrailingUnitNormalizer.WithOut[In, (A, B, C, D, E, F, G, H)] = new TrailingUnitNormalizer[In] {
+    implicit def arity8[In, A, B, C, D, E, F, G, H](implicit ev: (A, (B, (C, (D, (E, (F, (G, (H, Unit)))))))) =:= In): TrailingUnitNormalizer.WithOut[In, (A, B, C, D, E, F, G, H)] = new TrailingUnitNormalizer[In] {
       override type Out = (A, B, C, D, E, F, G, H)
 
-      override def apply(in: In): Out = (in._1, in._2._1, in._2._2._1, in._2._2._2._1, in._2._2._2._2._1, in._2._2._2._2._2._1, in._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._1)
+      override def apply(in0: In): Out = {
+        val in = in0.asInstanceOf[(A, (B, (C, (D, (E, (F, (G, (H, Unit))))))))]
+
+        (in._1, in._2._1, in._2._2._1, in._2._2._2._1, in._2._2._2._2._1, in._2._2._2._2._2._1, in._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._1)
+      }
     }
 
-    implicit def arity9[In, A, B, C, D, E, F, G, H, I](implicit ev: In =:= (A, (B, (C, (D, (E, (F, (G, (H, (I, Unit)))))))))): TrailingUnitNormalizer.WithOut[In, (A, B, C, D, E, F, G, H, I)] = new TrailingUnitNormalizer[In] {
+    implicit def arity9[In, A, B, C, D, E, F, G, H, I](implicit ev: (A, (B, (C, (D, (E, (F, (G, (H, (I, Unit))))))))) =:= In): TrailingUnitNormalizer.WithOut[In, (A, B, C, D, E, F, G, H, I)] = new TrailingUnitNormalizer[In] {
       override type Out = (A, B, C, D, E, F, G, H, I)
 
-      override def apply(in: In): Out = (in._1, in._2._1, in._2._2._1, in._2._2._2._1, in._2._2._2._2._1, in._2._2._2._2._2._1, in._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._1)
+      override def apply(in0: In): Out = {
+        val in = in0.asInstanceOf[(A, (B, (C, (D, (E, (F, (G, (H, (I, Unit)))))))))]
+        (in._1, in._2._1, in._2._2._1, in._2._2._2._1, in._2._2._2._2._1, in._2._2._2._2._2._1, in._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._1)
+      }
     }
 
-    implicit def arity10[In, A, B, C, D, E, F, G, H, I, J](implicit ev: In =:= (A, (B, (C, (D, (E, (F, (G, (H, (I, (J, Unit))))))))))): TrailingUnitNormalizer.WithOut[In, (A, B, C, D, E, F, G, H, I, J)] = new TrailingUnitNormalizer[In] {
+    implicit def arity10[In, A, B, C, D, E, F, G, H, I, J](implicit ev: (A, (B, (C, (D, (E, (F, (G, (H, (I, (J, Unit)))))))))) =:= In): TrailingUnitNormalizer.WithOut[In, (A, B, C, D, E, F, G, H, I, J)] = new TrailingUnitNormalizer[In] {
       override type Out = (A, B, C, D, E, F, G, H, I, J)
 
-      override def apply(in: In): Out = (in._1, in._2._1, in._2._2._1, in._2._2._2._1, in._2._2._2._2._1, in._2._2._2._2._2._1, in._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._1)
+      override def apply(in0: In): Out = {
+        val in = in0.asInstanceOf[(A, (B, (C, (D, (E, (F, (G, (H, (I, (J, Unit))))))))))]
+
+        (in._1, in._2._1, in._2._2._1, in._2._2._2._1, in._2._2._2._2._1, in._2._2._2._2._2._1, in._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._1)
+      }
     }
 
-    implicit def arity11[In, A, B, C, D, E, F, G, H, I, J, K](implicit ev: In =:= (A, (B, (C, (D, (E, (F, (G, (H, (I, (J, (K, Unit)))))))))))): TrailingUnitNormalizer.WithOut[In, (A, B, C, D, E, F, G, H, I, J, K)] = new TrailingUnitNormalizer[In] {
+    implicit def arity11[In, A, B, C, D, E, F, G, H, I, J, K](implicit ev: (A, (B, (C, (D, (E, (F, (G, (H, (I, (J, (K, Unit))))))))))) =:= In): TrailingUnitNormalizer.WithOut[In, (A, B, C, D, E, F, G, H, I, J, K)] = new TrailingUnitNormalizer[In] {
       override type Out = (A, B, C, D, E, F, G, H, I, J, K)
 
-      override def apply(in: In): Out = (in._1, in._2._1, in._2._2._1, in._2._2._2._1, in._2._2._2._2._1, in._2._2._2._2._2._1, in._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._1)
+      override def apply(in0: In): Out = {
+        val in = in0.asInstanceOf[(A, (B, (C, (D, (E, (F, (G, (H, (I, (J, (K, Unit)))))))))))]
+
+        (in._1, in._2._1, in._2._2._1, in._2._2._2._1, in._2._2._2._2._1, in._2._2._2._2._2._1, in._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._1)
+      }
     }
 
-    implicit def arity12[In, A, B, C, D, E, F, G, H, I, J, K, L](implicit ev: In =:= (A, (B, (C, (D, (E, (F, (G, (H, (I, (J, (K, (L, Unit))))))))))))): TrailingUnitNormalizer.WithOut[In, (A, B, C, D, E, F, G, H, I, J, K, L)] = new TrailingUnitNormalizer[In] {
+    implicit def arity12[In, A, B, C, D, E, F, G, H, I, J, K, L](implicit ev: (A, (B, (C, (D, (E, (F, (G, (H, (I, (J, (K, (L, Unit)))))))))))) =:= In): TrailingUnitNormalizer.WithOut[In, (A, B, C, D, E, F, G, H, I, J, K, L)] = new TrailingUnitNormalizer[In] {
       override type Out = (A, B, C, D, E, F, G, H, I, J, K, L)
 
-      override def apply(in: In): Out = (in._1, in._2._1, in._2._2._1, in._2._2._2._1, in._2._2._2._2._1, in._2._2._2._2._2._1, in._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._1)
+      override def apply(in0: In): Out = {
+        val in = in0.asInstanceOf[(A, (B, (C, (D, (E, (F, (G, (H, (I, (J, (K, (L, Unit))))))))))))]
+
+        (in._1, in._2._1, in._2._2._1, in._2._2._2._1, in._2._2._2._2._1, in._2._2._2._2._2._1, in._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._1)
+      }
     }
 
-    implicit def arity13[In, A, B, C, D, E, F, G, H, I, J, K, L, M](implicit ev: In =:= (A, (B, (C, (D, (E, (F, (G, (H, (I, (J, (K, (L, (M, Unit)))))))))))))): TrailingUnitNormalizer.WithOut[In, (A, B, C, D, E, F, G, H, I, J, K, L, M)] = new TrailingUnitNormalizer[In] {
+    implicit def arity13[In, A, B, C, D, E, F, G, H, I, J, K, L, M](implicit ev: (A, (B, (C, (D, (E, (F, (G, (H, (I, (J, (K, (L, (M, Unit))))))))))))) =:= In): TrailingUnitNormalizer.WithOut[In, (A, B, C, D, E, F, G, H, I, J, K, L, M)] = new TrailingUnitNormalizer[In] {
       override type Out = (A, B, C, D, E, F, G, H, I, J, K, L, M)
 
-      override def apply(in: In): Out = (in._1, in._2._1, in._2._2._1, in._2._2._2._1, in._2._2._2._2._1, in._2._2._2._2._2._1, in._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._1)
+      override def apply(in0: In): Out = {
+        val in = in0.asInstanceOf[(A, (B, (C, (D, (E, (F, (G, (H, (I, (J, (K, (L, (M, Unit)))))))))))))]
+
+        (in._1, in._2._1, in._2._2._1, in._2._2._2._1, in._2._2._2._2._1, in._2._2._2._2._2._1, in._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._1)
+      }
     }
 
-    implicit def arity14[In, A, B, C, D, E, F, G, H, I, J, K, L, M, N](implicit ev: In =:= (A, (B, (C, (D, (E, (F, (G, (H, (I, (J, (K, (L, (M, (N, Unit))))))))))))))): TrailingUnitNormalizer.WithOut[In, (A, B, C, D, E, F, G, H, I, J, K, L, M, N)] = new TrailingUnitNormalizer[In] {
+    implicit def arity14[In, A, B, C, D, E, F, G, H, I, J, K, L, M, N](implicit ev: (A, (B, (C, (D, (E, (F, (G, (H, (I, (J, (K, (L, (M, (N, Unit)))))))))))))) =:= In): TrailingUnitNormalizer.WithOut[In, (A, B, C, D, E, F, G, H, I, J, K, L, M, N)] = new TrailingUnitNormalizer[In] {
       override type Out = (A, B, C, D, E, F, G, H, I, J, K, L, M, N)
 
-      override def apply(in: In): Out = (in._1, in._2._1, in._2._2._1, in._2._2._2._1, in._2._2._2._2._1, in._2._2._2._2._2._1, in._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._1)
+      override def apply(in0: In): Out = {
+        val in = in0.asInstanceOf[(A, (B, (C, (D, (E, (F, (G, (H, (I, (J, (K, (L, (M, (N, Unit))))))))))))))]
+
+        (in._1, in._2._1, in._2._2._1, in._2._2._2._1, in._2._2._2._2._1, in._2._2._2._2._2._1, in._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._1)
+      }
     }
 
-    implicit def arity15[In, A, B, C, D, E, F, G, H, I, J, K, L, M, N, O](implicit ev: In =:= (A, (B, (C, (D, (E, (F, (G, (H, (I, (J, (K, (L, (M, (N, (O, Unit)))))))))))))))): TrailingUnitNormalizer.WithOut[In, (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O)] = new TrailingUnitNormalizer[In] {
+    implicit def arity15[In, A, B, C, D, E, F, G, H, I, J, K, L, M, N, O](implicit ev: (A, (B, (C, (D, (E, (F, (G, (H, (I, (J, (K, (L, (M, (N, (O, Unit))))))))))))))) =:= In): TrailingUnitNormalizer.WithOut[In, (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O)] = new TrailingUnitNormalizer[In] {
       override type Out = (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O)
 
-      override def apply(in: In): Out = (in._1, in._2._1, in._2._2._1, in._2._2._2._1, in._2._2._2._2._1, in._2._2._2._2._2._1, in._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._2._1)
+      override def apply(in0: In): Out = {
+        val in = in0.asInstanceOf[(A, (B, (C, (D, (E, (F, (G, (H, (I, (J, (K, (L, (M, (N, (O, Unit)))))))))))))))]
+
+        (in._1, in._2._1, in._2._2._1, in._2._2._2._1, in._2._2._2._2._1, in._2._2._2._2._2._1, in._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._2._1)
+      }
     }
 
-    implicit def arity16[In, A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P](implicit ev: In =:= (A, (B, (C, (D, (E, (F, (G, (H, (I, (J, (K, (L, (M, (N, (O, (P, Unit))))))))))))))))): TrailingUnitNormalizer.WithOut[In, (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P)] = new TrailingUnitNormalizer[In] {
+    implicit def arity16[In, A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P](implicit ev: (A, (B, (C, (D, (E, (F, (G, (H, (I, (J, (K, (L, (M, (N, (O, (P, Unit)))))))))))))))) =:= In): TrailingUnitNormalizer.WithOut[In, (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P)] = new TrailingUnitNormalizer[In] {
       override type Out = (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P)
 
-      override def apply(in: In): Out = (in._1, in._2._1, in._2._2._1, in._2._2._2._1, in._2._2._2._2._1, in._2._2._2._2._2._1, in._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._1)
+      override def apply(in0: In): Out = {
+        val in = in0.asInstanceOf[(A, (B, (C, (D, (E, (F, (G, (H, (I, (J, (K, (L, (M, (N, (O, (P, Unit))))))))))))))))]
+
+        (in._1, in._2._1, in._2._2._1, in._2._2._2._1, in._2._2._2._2._1, in._2._2._2._2._2._1, in._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._1)
+      }
     }
 
-    implicit def arity17[In, A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q](implicit ev: In =:= (A, (B, (C, (D, (E, (F, (G, (H, (I, (J, (K, (L, (M, (N, (O, (P, (Q, Unit)))))))))))))))))): TrailingUnitNormalizer.WithOut[In, (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q)] = new TrailingUnitNormalizer[In] {
+    implicit def arity17[In, A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q](implicit ev: (A, (B, (C, (D, (E, (F, (G, (H, (I, (J, (K, (L, (M, (N, (O, (P, (Q, Unit))))))))))))))))) =:= In): TrailingUnitNormalizer.WithOut[In, (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q)] = new TrailingUnitNormalizer[In] {
       override type Out = (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q)
 
-      override def apply(in: In): Out = (in._1, in._2._1, in._2._2._1, in._2._2._2._1, in._2._2._2._2._1, in._2._2._2._2._2._1, in._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._1)
+      override def apply(in0: In): Out = {
+        val in = in0.asInstanceOf[(A, (B, (C, (D, (E, (F, (G, (H, (I, (J, (K, (L, (M, (N, (O, (P, (Q, Unit)))))))))))))))))]
+
+        (in._1, in._2._1, in._2._2._1, in._2._2._2._1, in._2._2._2._2._1, in._2._2._2._2._2._1, in._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._1)
+      }
     }
 
-    implicit def arity18[In, A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R](implicit ev: In =:= (A, (B, (C, (D, (E, (F, (G, (H, (I, (J, (K, (L, (M, (N, (O, (P, (Q, (R, Unit))))))))))))))))))): TrailingUnitNormalizer.WithOut[In, (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R)] = new TrailingUnitNormalizer[In] {
+    implicit def arity18[In, A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R](implicit ev: (A, (B, (C, (D, (E, (F, (G, (H, (I, (J, (K, (L, (M, (N, (O, (P, (Q, (R, Unit)))))))))))))))))) =:= In): TrailingUnitNormalizer.WithOut[In, (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R)] = new TrailingUnitNormalizer[In] {
       override type Out = (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R)
 
-      override def apply(in: In): Out = (in._1, in._2._1, in._2._2._1, in._2._2._2._1, in._2._2._2._2._1, in._2._2._2._2._2._1, in._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._1)
+      override def apply(in0: In): Out = {
+        val in = in0.asInstanceOf[(A, (B, (C, (D, (E, (F, (G, (H, (I, (J, (K, (L, (M, (N, (O, (P, (Q, (R, Unit))))))))))))))))))]
+
+        (in._1, in._2._1, in._2._2._1, in._2._2._2._1, in._2._2._2._2._1, in._2._2._2._2._2._1, in._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._1)
+      }
     }
 
-    implicit def arity19[In, A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S](implicit ev: In =:= (A, (B, (C, (D, (E, (F, (G, (H, (I, (J, (K, (L, (M, (N, (O, (P, (Q, (R, (S, Unit)))))))))))))))))))): TrailingUnitNormalizer.WithOut[In, (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S)] = new TrailingUnitNormalizer[In] {
+    implicit def arity19[In, A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S](implicit ev: (A, (B, (C, (D, (E, (F, (G, (H, (I, (J, (K, (L, (M, (N, (O, (P, (Q, (R, (S, Unit))))))))))))))))))) =:= In): TrailingUnitNormalizer.WithOut[In, (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S)] = new TrailingUnitNormalizer[In] {
       override type Out = (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S)
-override def apply(in: In): Out = (in._1, in._2._1, in._2._2._1, in._2._2._2._1, in._2._2._2._2._1, in._2._2._2._2._2._1, in._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._1)
+      override def apply(in0: In): Out = {
+        val in = in0.asInstanceOf[(A, (B, (C, (D, (E, (F, (G, (H, (I, (J, (K, (L, (M, (N, (O, (P, (Q, (R, (S, Unit)))))))))))))))))))]
+
+        (in._1, in._2._1, in._2._2._1, in._2._2._2._1, in._2._2._2._2._1, in._2._2._2._2._2._1, in._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._1)
+      }
     }
 
-    implicit def arity20[In, A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T](implicit ev: In =:= (A, (B, (C, (D, (E, (F, (G, (H, (I, (J, (K, (L, (M, (N, (O, (P, (Q, (R, (S, (T, Unit))))))))))))))))))))): TrailingUnitNormalizer.WithOut[In, (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T)] = new TrailingUnitNormalizer[In] {
+    implicit def arity20[In, A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T](implicit ev: (A, (B, (C, (D, (E, (F, (G, (H, (I, (J, (K, (L, (M, (N, (O, (P, (Q, (R, (S, (T, Unit)))))))))))))))))))) =:= In): TrailingUnitNormalizer.WithOut[In, (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T)] = new TrailingUnitNormalizer[In] {
       override type Out = (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T)
 
-      override def apply(in: In): Out = (in._1, in._2._1, in._2._2._1, in._2._2._2._1, in._2._2._2._2._1, in._2._2._2._2._2._1, in._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._1)
+      override def apply(in0: In): Out = {
+        val in = in0.asInstanceOf[(A, (B, (C, (D, (E, (F, (G, (H, (I, (J, (K, (L, (M, (N, (O, (P, (Q, (R, (S, (T, Unit))))))))))))))))))))]
+
+        (in._1, in._2._1, in._2._2._1, in._2._2._2._1, in._2._2._2._2._1, in._2._2._2._2._2._1, in._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._1)
+      }
     }
 
-    implicit def arity21[In, A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U](implicit ev: In =:= (A, (B, (C, (D, (E, (F, (G, (H, (I, (J, (K, (L, (M, (N, (O, (P, (Q, (R, (S, (T, (U, Unit)))))))))))))))))))))): TrailingUnitNormalizer.WithOut[In, (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U)] = new TrailingUnitNormalizer[In] {
+    implicit def arity21[In, A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U](implicit ev: (A, (B, (C, (D, (E, (F, (G, (H, (I, (J, (K, (L, (M, (N, (O, (P, (Q, (R, (S, (T, (U, Unit))))))))))))))))))))) =:= In): TrailingUnitNormalizer.WithOut[In, (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U)] = new TrailingUnitNormalizer[In] {
       override type Out = (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U)
 
-      override def apply(in: In): Out = (in._1, in._2._1, in._2._2._1, in._2._2._2._1, in._2._2._2._2._1, in._2._2._2._2._2._1, in._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._1)
+      override def apply(in0: In): Out = {
+        val in = in0.asInstanceOf[(A, (B, (C, (D, (E, (F, (G, (H, (I, (J, (K, (L, (M, (N, (O, (P, (Q, (R, (S, (T, (U, Unit)))))))))))))))))))))]
+
+        (in._1, in._2._1, in._2._2._1, in._2._2._2._1, in._2._2._2._2._1, in._2._2._2._2._2._1, in._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._1)
+      }
     }
 
-    implicit def arity22[In, A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V](implicit ev: In =:= (A, (B, (C, (D, (E, (F, (G, (H, (I, (J, (K, (L, (M, (N, (O, (P, (Q, (R, (S, (T, (U, (V, Unit))))))))))))))))))))))): TrailingUnitNormalizer.WithOut[In, (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V)] = new TrailingUnitNormalizer[In] {
+    implicit def arity22[In, A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V](implicit ev: (A, (B, (C, (D, (E, (F, (G, (H, (I, (J, (K, (L, (M, (N, (O, (P, (Q, (R, (S, (T, (U, (V, Unit)))))))))))))))))))))) =:= In): TrailingUnitNormalizer.WithOut[In, (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V)] = new TrailingUnitNormalizer[In] {
       override type Out = (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V)
 
-      override def apply(in: In): Out = (in._1, in._2._1, in._2._2._1, in._2._2._2._1, in._2._2._2._2._1, in._2._2._2._2._2._1, in._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._1)
+      override def apply(in0: In): Out = {
+        val in = in0.asInstanceOf[(A, (B, (C, (D, (E, (F, (G, (H, (I, (J, (K, (L, (M, (N, (O, (P, (Q, (R, (S, (T, (U, (V, Unit))))))))))))))))))))))]
+
+        (in._1, in._2._1, in._2._2._1, in._2._2._2._1, in._2._2._2._2._1, in._2._2._2._2._2._1, in._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._1)
+      }
     }
     // format: on
   }

--- a/core/jvm/src/main/scala/zio/sql/utils.scala
+++ b/core/jvm/src/main/scala/zio/sql/utils.scala
@@ -2,7 +2,7 @@ package zio.sql
 
 trait UtilsModule { self =>
   sealed trait TrailingUnitNormalizer[In] {
-      type Out
+    type Out
   }
 
   object TrailingUnitNormalizer {

--- a/core/jvm/src/main/scala/zio/sql/utils.scala
+++ b/core/jvm/src/main/scala/zio/sql/utils.scala
@@ -12,223 +12,157 @@ trait UtilsModule { self =>
       type Out = Out0
     }
     // format: off
-    //ev needs to be reversed because scala 2.12 cannot prove In =:= (A, Unit), therefore asInstanceOf
-    implicit def arity1[In, A](implicit ev: (A, Unit) =:= In) : TrailingUnitNormalizer.WithOut[In, A] = new TrailingUnitNormalizer[In] {
+    implicit def arity1[In, A]: TrailingUnitNormalizer.WithOut[(A, Unit), A] = new TrailingUnitNormalizer[(A, Unit)] {
       override type Out = A
 
-      override def apply(in0: In): A = {
-        val in = in0.asInstanceOf[(A, Unit)]
-
+      override def apply(in: (A, Unit)): A = 
         in._1
-      }
     }
 
-    implicit def arity2[In, A, B](implicit ev: (A, (B, Unit)) =:= In) : TrailingUnitNormalizer.WithOut[In, (A, B)] = new TrailingUnitNormalizer[In] {
+    implicit def arity2[In, A, B]: TrailingUnitNormalizer.WithOut[(A, (B, Unit)), (A, B)] = new TrailingUnitNormalizer[(A, (B, Unit))] {
       override type Out = (A, B)
 
-      override def apply(in0: In): Out = {
-        val in = in0.asInstanceOf[(A, (B, Unit))]
-
+      override def apply(in: (A, (B, Unit))): Out = 
         (in._1, in._2._1)
-      }
     }
 
-    implicit def arity3[In, A, B, C](implicit ev: (A, (B, (C, Unit))) =:= In) : TrailingUnitNormalizer.WithOut[In, (A, B, C)] = new TrailingUnitNormalizer[In] {
+    implicit def arity3[In, A, B, C]: TrailingUnitNormalizer.WithOut[(A, (B, (C, Unit))), (A, B, C)] = new TrailingUnitNormalizer[(A, (B, (C, Unit)))] {
       override type Out = (A, B, C)
 
-      override def apply(in0: In): Out = {
-        val in = in0.asInstanceOf[(A, (B, (C, Unit)))]
-
+      override def apply(in: (A, (B, (C, Unit))) ): Out = 
         (in._1, in._2._1, in._2._2._1)
-      }
     }
 
-    implicit def arity4[In, A, B, C, D](implicit ev: (A, (B, (C, (D, Unit)))) =:= In) : TrailingUnitNormalizer.WithOut[In, (A, B, C, D)] = new TrailingUnitNormalizer[In] {
+    implicit def arity4[In, A, B, C, D]: TrailingUnitNormalizer.WithOut[(A, (B, (C, (D, Unit)))), (A, B, C, D)] = new TrailingUnitNormalizer[(A, (B, (C, (D, Unit))))] {
       override type Out = (A, B, C, D)
 
-      override def apply(in0: In): Out = {
-        val in = in0.asInstanceOf[(A, (B, (C, (D, Unit))))]
-
+      override def apply(in: (A, (B, (C, (D, Unit))))): Out = 
         (in._1, in._2._1, in._2._2._1, in._2._2._2._1)
-      }
     }
 
-    implicit def arity5[In, A, B, C, D, E](implicit ev: (A, (B, (C, (D, (E, Unit))))) =:= In) : TrailingUnitNormalizer.WithOut[In, (A, B, C, D, E)] = new TrailingUnitNormalizer[In] {
+    implicit def arity5[In, A, B, C, D, E]: TrailingUnitNormalizer.WithOut[(A, (B, (C, (D, (E, Unit))))), (A, B, C, D, E)] = new TrailingUnitNormalizer[(A, (B, (C, (D, (E, Unit)))))] {
       override type Out = (A, B, C, D, E)
 
-      override def apply(in0: In): Out = {
-        val in = in0.asInstanceOf[(A, (B, (C, (D, (E, Unit)))))]
-
+      override def apply(in: (A, (B, (C, (D, (E, Unit)))))): Out = 
         (in._1, in._2._1, in._2._2._1, in._2._2._2._1, in._2._2._2._2._1)
-      }
     }
 
-    implicit def arity6[In, A, B, C, D, E, F](implicit ev: (A, (B, (C, (D, (E, (F, Unit)))))) =:= In) : TrailingUnitNormalizer.WithOut[In, (A, B, C, D, E, F)] = new TrailingUnitNormalizer[In] {
+    implicit def arity6[In, A, B, C, D, E, F]: TrailingUnitNormalizer.WithOut[(A, (B, (C, (D, (E, (F, Unit)))))), (A, B, C, D, E, F)] = new TrailingUnitNormalizer[(A, (B, (C, (D, (E, (F, Unit))))))] {
       override type Out = (A, B, C, D, E, F)
 
-      override def apply(in0: In): Out = {
-        val in = in0.asInstanceOf[(A, (B, (C, (D, (E, (F, Unit))))))]
-
+      override def apply(in: (A, (B, (C, (D, (E, (F, Unit))))))): Out = 
         (in._1, in._2._1, in._2._2._1, in._2._2._2._1, in._2._2._2._2._1,  in._2._2._2._2._2._1)
-      }
     }
 
-    implicit def arity7[In, A, B, C, D, E, F, G](implicit ev: (A, (B, (C, (D, (E, (F, (G, Unit))))))) =:= In): TrailingUnitNormalizer.WithOut[In, (A, B, C, D, E, F, G)] = new TrailingUnitNormalizer[In] {
+    implicit def arity7[In, A, B, C, D, E, F, G]: TrailingUnitNormalizer.WithOut[(A, (B, (C, (D, (E, (F, (G, Unit))))))), (A, B, C, D, E, F, G)] = new TrailingUnitNormalizer[(A, (B, (C, (D, (E, (F, (G, Unit)))))))] {
       override type Out = (A, B, C, D, E, F, G)
 
-      override def apply(in0: In): Out = {
-        val in = in0.asInstanceOf[(A, (B, (C, (D, (E, (F, (G, Unit)))))))]
-
+      override def apply(in: (A, (B, (C, (D, (E, (F, (G, Unit)))))))): Out = 
         (in._1, in._2._1, in._2._2._1, in._2._2._2._1, in._2._2._2._2._1, in._2._2._2._2._2._1, in._2._2._2._2._2._2._1)
-      }
     }
 
-    implicit def arity8[In, A, B, C, D, E, F, G, H](implicit ev: (A, (B, (C, (D, (E, (F, (G, (H, Unit)))))))) =:= In): TrailingUnitNormalizer.WithOut[In, (A, B, C, D, E, F, G, H)] = new TrailingUnitNormalizer[In] {
+    implicit def arity8[In, A, B, C, D, E, F, G, H]: TrailingUnitNormalizer.WithOut[(A, (B, (C, (D, (E, (F, (G, (H, Unit)))))))), (A, B, C, D, E, F, G, H)] = new TrailingUnitNormalizer[(A, (B, (C, (D, (E, (F, (G, (H, Unit))))))))] {
       override type Out = (A, B, C, D, E, F, G, H)
 
-      override def apply(in0: In): Out = {
-        val in = in0.asInstanceOf[(A, (B, (C, (D, (E, (F, (G, (H, Unit))))))))]
-
+      override def apply(in: (A, (B, (C, (D, (E, (F, (G, (H, Unit))))))))): Out =
         (in._1, in._2._1, in._2._2._1, in._2._2._2._1, in._2._2._2._2._1, in._2._2._2._2._2._1, in._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._1)
-      }
     }
 
-    implicit def arity9[In, A, B, C, D, E, F, G, H, I](implicit ev: (A, (B, (C, (D, (E, (F, (G, (H, (I, Unit))))))))) =:= In): TrailingUnitNormalizer.WithOut[In, (A, B, C, D, E, F, G, H, I)] = new TrailingUnitNormalizer[In] {
+    implicit def arity9[In, A, B, C, D, E, F, G, H, I]: TrailingUnitNormalizer.WithOut[(A, (B, (C, (D, (E, (F, (G, (H, (I, Unit))))))))), (A, B, C, D, E, F, G, H, I)] = new TrailingUnitNormalizer[(A, (B, (C, (D, (E, (F, (G, (H, (I, Unit)))))))))] {
       override type Out = (A, B, C, D, E, F, G, H, I)
 
-      override def apply(in0: In): Out = {
-        val in = in0.asInstanceOf[(A, (B, (C, (D, (E, (F, (G, (H, (I, Unit)))))))))]
+      override def apply(in: (A, (B, (C, (D, (E, (F, (G, (H, (I, Unit)))))))))): Out = 
         (in._1, in._2._1, in._2._2._1, in._2._2._2._1, in._2._2._2._2._1, in._2._2._2._2._2._1, in._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._1)
-      }
     }
 
-    implicit def arity10[In, A, B, C, D, E, F, G, H, I, J](implicit ev: (A, (B, (C, (D, (E, (F, (G, (H, (I, (J, Unit)))))))))) =:= In): TrailingUnitNormalizer.WithOut[In, (A, B, C, D, E, F, G, H, I, J)] = new TrailingUnitNormalizer[In] {
+    implicit def arity10[In, A, B, C, D, E, F, G, H, I, J]: TrailingUnitNormalizer.WithOut[(A, (B, (C, (D, (E, (F, (G, (H, (I, (J, Unit)))))))))), (A, B, C, D, E, F, G, H, I, J)] = new TrailingUnitNormalizer[(A, (B, (C, (D, (E, (F, (G, (H, (I, (J, Unit))))))))))] {
       override type Out = (A, B, C, D, E, F, G, H, I, J)
 
-      override def apply(in0: In): Out = {
-        val in = in0.asInstanceOf[(A, (B, (C, (D, (E, (F, (G, (H, (I, (J, Unit))))))))))]
-
+      override def apply(in: (A, (B, (C, (D, (E, (F, (G, (H, (I, (J, Unit))))))))))): Out = 
         (in._1, in._2._1, in._2._2._1, in._2._2._2._1, in._2._2._2._2._1, in._2._2._2._2._2._1, in._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._1)
-      }
     }
 
-    implicit def arity11[In, A, B, C, D, E, F, G, H, I, J, K](implicit ev: (A, (B, (C, (D, (E, (F, (G, (H, (I, (J, (K, Unit))))))))))) =:= In): TrailingUnitNormalizer.WithOut[In, (A, B, C, D, E, F, G, H, I, J, K)] = new TrailingUnitNormalizer[In] {
+    implicit def arity11[In, A, B, C, D, E, F, G, H, I, J, K]: TrailingUnitNormalizer.WithOut[(A, (B, (C, (D, (E, (F, (G, (H, (I, (J, (K, Unit))))))))))), (A, B, C, D, E, F, G, H, I, J, K)] = new TrailingUnitNormalizer[(A, (B, (C, (D, (E, (F, (G, (H, (I, (J, (K, Unit)))))))))))] {
       override type Out = (A, B, C, D, E, F, G, H, I, J, K)
 
-      override def apply(in0: In): Out = {
-        val in = in0.asInstanceOf[(A, (B, (C, (D, (E, (F, (G, (H, (I, (J, (K, Unit)))))))))))]
-
+      override def apply(in: (A, (B, (C, (D, (E, (F, (G, (H, (I, (J, (K, Unit)))))))))))): Out = 
         (in._1, in._2._1, in._2._2._1, in._2._2._2._1, in._2._2._2._2._1, in._2._2._2._2._2._1, in._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._1)
-      }
     }
 
-    implicit def arity12[In, A, B, C, D, E, F, G, H, I, J, K, L](implicit ev: (A, (B, (C, (D, (E, (F, (G, (H, (I, (J, (K, (L, Unit)))))))))))) =:= In): TrailingUnitNormalizer.WithOut[In, (A, B, C, D, E, F, G, H, I, J, K, L)] = new TrailingUnitNormalizer[In] {
+    implicit def arity12[In, A, B, C, D, E, F, G, H, I, J, K, L]: TrailingUnitNormalizer.WithOut[(A, (B, (C, (D, (E, (F, (G, (H, (I, (J, (K, (L, Unit)))))))))))), (A, B, C, D, E, F, G, H, I, J, K, L)] = new TrailingUnitNormalizer[(A, (B, (C, (D, (E, (F, (G, (H, (I, (J, (K, (L, Unit))))))))))))] {
       override type Out = (A, B, C, D, E, F, G, H, I, J, K, L)
 
-      override def apply(in0: In): Out = {
-        val in = in0.asInstanceOf[(A, (B, (C, (D, (E, (F, (G, (H, (I, (J, (K, (L, Unit))))))))))))]
-
+      override def apply(in: (A, (B, (C, (D, (E, (F, (G, (H, (I, (J, (K, (L, Unit))))))))))))): Out = 
         (in._1, in._2._1, in._2._2._1, in._2._2._2._1, in._2._2._2._2._1, in._2._2._2._2._2._1, in._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._1)
-      }
     }
 
-    implicit def arity13[In, A, B, C, D, E, F, G, H, I, J, K, L, M](implicit ev: (A, (B, (C, (D, (E, (F, (G, (H, (I, (J, (K, (L, (M, Unit))))))))))))) =:= In): TrailingUnitNormalizer.WithOut[In, (A, B, C, D, E, F, G, H, I, J, K, L, M)] = new TrailingUnitNormalizer[In] {
+    implicit def arity13[In, A, B, C, D, E, F, G, H, I, J, K, L, M]: TrailingUnitNormalizer.WithOut[(A, (B, (C, (D, (E, (F, (G, (H, (I, (J, (K, (L, (M, Unit))))))))))))), (A, B, C, D, E, F, G, H, I, J, K, L, M)] = new TrailingUnitNormalizer[(A, (B, (C, (D, (E, (F, (G, (H, (I, (J, (K, (L, (M, Unit)))))))))))))] {
       override type Out = (A, B, C, D, E, F, G, H, I, J, K, L, M)
 
-      override def apply(in0: In): Out = {
-        val in = in0.asInstanceOf[(A, (B, (C, (D, (E, (F, (G, (H, (I, (J, (K, (L, (M, Unit)))))))))))))]
-
+      override def apply(in:  (A, (B, (C, (D, (E, (F, (G, (H, (I, (J, (K, (L, (M, Unit)))))))))))))): Out = 
         (in._1, in._2._1, in._2._2._1, in._2._2._2._1, in._2._2._2._2._1, in._2._2._2._2._2._1, in._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._1)
-      }
     }
 
-    implicit def arity14[In, A, B, C, D, E, F, G, H, I, J, K, L, M, N](implicit ev: (A, (B, (C, (D, (E, (F, (G, (H, (I, (J, (K, (L, (M, (N, Unit)))))))))))))) =:= In): TrailingUnitNormalizer.WithOut[In, (A, B, C, D, E, F, G, H, I, J, K, L, M, N)] = new TrailingUnitNormalizer[In] {
+    implicit def arity14[In, A, B, C, D, E, F, G, H, I, J, K, L, M, N]: TrailingUnitNormalizer.WithOut[(A, (B, (C, (D, (E, (F, (G, (H, (I, (J, (K, (L, (M, (N, Unit)))))))))))))), (A, B, C, D, E, F, G, H, I, J, K, L, M, N)] = new TrailingUnitNormalizer[(A, (B, (C, (D, (E, (F, (G, (H, (I, (J, (K, (L, (M, (N, Unit))))))))))))))] {
       override type Out = (A, B, C, D, E, F, G, H, I, J, K, L, M, N)
 
-      override def apply(in0: In): Out = {
-        val in = in0.asInstanceOf[(A, (B, (C, (D, (E, (F, (G, (H, (I, (J, (K, (L, (M, (N, Unit))))))))))))))]
-
+      override def apply(in: (A, (B, (C, (D, (E, (F, (G, (H, (I, (J, (K, (L, (M, (N, Unit))))))))))))))): Out = 
         (in._1, in._2._1, in._2._2._1, in._2._2._2._1, in._2._2._2._2._1, in._2._2._2._2._2._1, in._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._1)
-      }
     }
 
-    implicit def arity15[In, A, B, C, D, E, F, G, H, I, J, K, L, M, N, O](implicit ev: (A, (B, (C, (D, (E, (F, (G, (H, (I, (J, (K, (L, (M, (N, (O, Unit))))))))))))))) =:= In): TrailingUnitNormalizer.WithOut[In, (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O)] = new TrailingUnitNormalizer[In] {
+    implicit def arity15[In, A, B, C, D, E, F, G, H, I, J, K, L, M, N, O]: TrailingUnitNormalizer.WithOut[(A, (B, (C, (D, (E, (F, (G, (H, (I, (J, (K, (L, (M, (N, (O, Unit))))))))))))))), (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O)] = new TrailingUnitNormalizer[(A, (B, (C, (D, (E, (F, (G, (H, (I, (J, (K, (L, (M, (N, (O, Unit)))))))))))))))] {
       override type Out = (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O)
 
-      override def apply(in0: In): Out = {
-        val in = in0.asInstanceOf[(A, (B, (C, (D, (E, (F, (G, (H, (I, (J, (K, (L, (M, (N, (O, Unit)))))))))))))))]
-
+      override def apply(in: (A, (B, (C, (D, (E, (F, (G, (H, (I, (J, (K, (L, (M, (N, (O, Unit)))))))))))))))): Out = 
         (in._1, in._2._1, in._2._2._1, in._2._2._2._1, in._2._2._2._2._1, in._2._2._2._2._2._1, in._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._2._1)
-      }
     }
 
-    implicit def arity16[In, A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P](implicit ev: (A, (B, (C, (D, (E, (F, (G, (H, (I, (J, (K, (L, (M, (N, (O, (P, Unit)))))))))))))))) =:= In): TrailingUnitNormalizer.WithOut[In, (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P)] = new TrailingUnitNormalizer[In] {
+    implicit def arity16[In, A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P]: TrailingUnitNormalizer.WithOut[(A, (B, (C, (D, (E, (F, (G, (H, (I, (J, (K, (L, (M, (N, (O, (P, Unit)))))))))))))))), (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P)] = new TrailingUnitNormalizer[(A, (B, (C, (D, (E, (F, (G, (H, (I, (J, (K, (L, (M, (N, (O, (P, Unit))))))))))))))))] {
       override type Out = (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P)
 
-      override def apply(in0: In): Out = {
-        val in = in0.asInstanceOf[(A, (B, (C, (D, (E, (F, (G, (H, (I, (J, (K, (L, (M, (N, (O, (P, Unit))))))))))))))))]
-
+      override def apply(in: (A, (B, (C, (D, (E, (F, (G, (H, (I, (J, (K, (L, (M, (N, (O, (P, Unit)))))))))))))))) ): Out =
         (in._1, in._2._1, in._2._2._1, in._2._2._2._1, in._2._2._2._2._1, in._2._2._2._2._2._1, in._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._1)
-      }
     }
 
-    implicit def arity17[In, A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q](implicit ev: (A, (B, (C, (D, (E, (F, (G, (H, (I, (J, (K, (L, (M, (N, (O, (P, (Q, Unit))))))))))))))))) =:= In): TrailingUnitNormalizer.WithOut[In, (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q)] = new TrailingUnitNormalizer[In] {
+    implicit def arity17[In, A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q]: TrailingUnitNormalizer.WithOut[(A, (B, (C, (D, (E, (F, (G, (H, (I, (J, (K, (L, (M, (N, (O, (P, (Q, Unit))))))))))))))))), (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q)] = new TrailingUnitNormalizer[(A, (B, (C, (D, (E, (F, (G, (H, (I, (J, (K, (L, (M, (N, (O, (P, (Q, Unit)))))))))))))))))] {
       override type Out = (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q)
 
-      override def apply(in0: In): Out = {
-        val in = in0.asInstanceOf[(A, (B, (C, (D, (E, (F, (G, (H, (I, (J, (K, (L, (M, (N, (O, (P, (Q, Unit)))))))))))))))))]
-
+      override def apply(in: (A, (B, (C, (D, (E, (F, (G, (H, (I, (J, (K, (L, (M, (N, (O, (P, (Q, Unit)))))))))))))))))): Out = 
         (in._1, in._2._1, in._2._2._1, in._2._2._2._1, in._2._2._2._2._1, in._2._2._2._2._2._1, in._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._1)
-      }
     }
 
-    implicit def arity18[In, A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R](implicit ev: (A, (B, (C, (D, (E, (F, (G, (H, (I, (J, (K, (L, (M, (N, (O, (P, (Q, (R, Unit)))))))))))))))))) =:= In): TrailingUnitNormalizer.WithOut[In, (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R)] = new TrailingUnitNormalizer[In] {
+    implicit def arity18[In, A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R]: TrailingUnitNormalizer.WithOut[(A, (B, (C, (D, (E, (F, (G, (H, (I, (J, (K, (L, (M, (N, (O, (P, (Q, (R, Unit)))))))))))))))))), (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R)] = new TrailingUnitNormalizer[(A, (B, (C, (D, (E, (F, (G, (H, (I, (J, (K, (L, (M, (N, (O, (P, (Q, (R, Unit))))))))))))))))))] {
       override type Out = (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R)
 
-      override def apply(in0: In): Out = {
-        val in = in0.asInstanceOf[(A, (B, (C, (D, (E, (F, (G, (H, (I, (J, (K, (L, (M, (N, (O, (P, (Q, (R, Unit))))))))))))))))))]
-
+      override def apply(in: (A, (B, (C, (D, (E, (F, (G, (H, (I, (J, (K, (L, (M, (N, (O, (P, (Q, (R, Unit))))))))))))))))))): Out = 
         (in._1, in._2._1, in._2._2._1, in._2._2._2._1, in._2._2._2._2._1, in._2._2._2._2._2._1, in._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._1)
-      }
     }
 
-    implicit def arity19[In, A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S](implicit ev: (A, (B, (C, (D, (E, (F, (G, (H, (I, (J, (K, (L, (M, (N, (O, (P, (Q, (R, (S, Unit))))))))))))))))))) =:= In): TrailingUnitNormalizer.WithOut[In, (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S)] = new TrailingUnitNormalizer[In] {
+    implicit def arity19[In, A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S]: TrailingUnitNormalizer.WithOut[(A, (B, (C, (D, (E, (F, (G, (H, (I, (J, (K, (L, (M, (N, (O, (P, (Q, (R, (S, Unit))))))))))))))))))), (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S)] = new TrailingUnitNormalizer[(A, (B, (C, (D, (E, (F, (G, (H, (I, (J, (K, (L, (M, (N, (O, (P, (Q, (R, (S, Unit)))))))))))))))))))] {
       override type Out = (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S)
-      override def apply(in0: In): Out = {
-        val in = in0.asInstanceOf[(A, (B, (C, (D, (E, (F, (G, (H, (I, (J, (K, (L, (M, (N, (O, (P, (Q, (R, (S, Unit)))))))))))))))))))]
-
+      override def apply(in: (A, (B, (C, (D, (E, (F, (G, (H, (I, (J, (K, (L, (M, (N, (O, (P, (Q, (R, (S, Unit))))))))))))))))))) ): Out = 
         (in._1, in._2._1, in._2._2._1, in._2._2._2._1, in._2._2._2._2._1, in._2._2._2._2._2._1, in._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._1)
-      }
     }
 
-    implicit def arity20[In, A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T](implicit ev: (A, (B, (C, (D, (E, (F, (G, (H, (I, (J, (K, (L, (M, (N, (O, (P, (Q, (R, (S, (T, Unit)))))))))))))))))))) =:= In): TrailingUnitNormalizer.WithOut[In, (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T)] = new TrailingUnitNormalizer[In] {
+    implicit def arity20[In, A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T]: TrailingUnitNormalizer.WithOut[(A, (B, (C, (D, (E, (F, (G, (H, (I, (J, (K, (L, (M, (N, (O, (P, (Q, (R, (S, (T, Unit)))))))))))))))))))), (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T)] = new TrailingUnitNormalizer[(A, (B, (C, (D, (E, (F, (G, (H, (I, (J, (K, (L, (M, (N, (O, (P, (Q, (R, (S, (T, Unit))))))))))))))))))))] {
       override type Out = (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T)
 
-      override def apply(in0: In): Out = {
-        val in = in0.asInstanceOf[(A, (B, (C, (D, (E, (F, (G, (H, (I, (J, (K, (L, (M, (N, (O, (P, (Q, (R, (S, (T, Unit))))))))))))))))))))]
-
+      override def apply(in: (A, (B, (C, (D, (E, (F, (G, (H, (I, (J, (K, (L, (M, (N, (O, (P, (Q, (R, (S, (T, Unit))))))))))))))))))))): Out = 
         (in._1, in._2._1, in._2._2._1, in._2._2._2._1, in._2._2._2._2._1, in._2._2._2._2._2._1, in._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._1)
-      }
     }
 
-    implicit def arity21[In, A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U](implicit ev: (A, (B, (C, (D, (E, (F, (G, (H, (I, (J, (K, (L, (M, (N, (O, (P, (Q, (R, (S, (T, (U, Unit))))))))))))))))))))) =:= In): TrailingUnitNormalizer.WithOut[In, (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U)] = new TrailingUnitNormalizer[In] {
+    implicit def arity21[In, A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U]: TrailingUnitNormalizer.WithOut[(A, (B, (C, (D, (E, (F, (G, (H, (I, (J, (K, (L, (M, (N, (O, (P, (Q, (R, (S, (T, (U, Unit))))))))))))))))))))), (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U)] = new TrailingUnitNormalizer[(A, (B, (C, (D, (E, (F, (G, (H, (I, (J, (K, (L, (M, (N, (O, (P, (Q, (R, (S, (T, (U, Unit)))))))))))))))))))))] {
       override type Out = (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U)
 
-      override def apply(in0: In): Out = {
-        val in = in0.asInstanceOf[(A, (B, (C, (D, (E, (F, (G, (H, (I, (J, (K, (L, (M, (N, (O, (P, (Q, (R, (S, (T, (U, Unit)))))))))))))))))))))]
-
+      override def apply(in: (A, (B, (C, (D, (E, (F, (G, (H, (I, (J, (K, (L, (M, (N, (O, (P, (Q, (R, (S, (T, (U, Unit)))))))))))))))))))))): Out = 
         (in._1, in._2._1, in._2._2._1, in._2._2._2._1, in._2._2._2._2._1, in._2._2._2._2._2._1, in._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._1)
-      }
     }
 
-    implicit def arity22[In, A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V](implicit ev: (A, (B, (C, (D, (E, (F, (G, (H, (I, (J, (K, (L, (M, (N, (O, (P, (Q, (R, (S, (T, (U, (V, Unit)))))))))))))))))))))) =:= In): TrailingUnitNormalizer.WithOut[In, (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V)] = new TrailingUnitNormalizer[In] {
+    implicit def arity22[In, A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V]: TrailingUnitNormalizer.WithOut[(A, (B, (C, (D, (E, (F, (G, (H, (I, (J, (K, (L, (M, (N, (O, (P, (Q, (R, (S, (T, (U, (V, Unit)))))))))))))))))))))), (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V)] = new TrailingUnitNormalizer[(A, (B, (C, (D, (E, (F, (G, (H, (I, (J, (K, (L, (M, (N, (O, (P, (Q, (R, (S, (T, (U, (V, Unit))))))))))))))))))))))] {
       override type Out = (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V)
 
-      override def apply(in0: In): Out = {
-        val in = in0.asInstanceOf[(A, (B, (C, (D, (E, (F, (G, (H, (I, (J, (K, (L, (M, (N, (O, (P, (Q, (R, (S, (T, (U, (V, Unit))))))))))))))))))))))]
-
+      override def apply(in: (A, (B, (C, (D, (E, (F, (G, (H, (I, (J, (K, (L, (M, (N, (O, (P, (Q, (R, (S, (T, (U, (V, Unit))))))))))))))))))))))): Out = 
         (in._1, in._2._1, in._2._2._1, in._2._2._2._1, in._2._2._2._2._1, in._2._2._2._2._2._1, in._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._1)
-      }
     }
     // format: on
   }

--- a/core/jvm/src/main/scala/zio/sql/utils.scala
+++ b/core/jvm/src/main/scala/zio/sql/utils.scala
@@ -1,0 +1,102 @@
+package zio.sql
+
+trait UtilsModule { self =>
+  sealed trait TrailingUnitNormalizer[In] {
+      type Out
+  }
+
+  object TrailingUnitNormalizer {
+    type WithOut[In0, Out0] = TrailingUnitNormalizer[In0] {
+      type Out = Out0
+    }
+    // format: off
+    implicit def arity1[In, A](implicit ev: In =:= (A, Unit)) : TrailingUnitNormalizer.WithOut[In, A] = new TrailingUnitNormalizer[In] {
+      override type Out = A
+    }
+
+    implicit def arity2[In, A, B](implicit ev: In =:= (A, (B, Unit))) : TrailingUnitNormalizer.WithOut[In, (A, B)] = new TrailingUnitNormalizer[In] {
+      override type Out = (A, B)
+    }
+
+    implicit def arity3[In, A, B, C](implicit ev: In =:= (A, (B, (C, Unit)))) : TrailingUnitNormalizer.WithOut[In, (A, B, C)] = new TrailingUnitNormalizer[In] {
+      override type Out = (A, B, C)
+    }
+
+    implicit def arity4[In, A, B, C, D](implicit ev: In =:= (A, (B, (C, (D, Unit))))) : TrailingUnitNormalizer.WithOut[In, (A, B, C, D)] = new TrailingUnitNormalizer[In] {
+      override type Out = (A, B, C, D)
+    }
+
+    implicit def arity5[In, A, B, C, D, E](implicit ev: In =:= (A, (B, (C, (D, (E, Unit)))))) : TrailingUnitNormalizer.WithOut[In, (A, B, C, D, E)] = new TrailingUnitNormalizer[In] {
+      override type Out = (A, B, C, D, E)
+    }
+
+    implicit def arity6[In, A, B, C, D, E, F](implicit ev: In =:= (A, (B, (C, (D, (E, (F, Unit))))))) : TrailingUnitNormalizer.WithOut[In, (A, B, C, D, E, F)] = new TrailingUnitNormalizer[In] {
+      override type Out = (A, B, C, D, E, F)
+    }
+
+    implicit def arity7[In, A, B, C, D, E, F, G](implicit ev: In =:= (A, (B, (C, (D, (E, (F, (G, Unit)))))))): TrailingUnitNormalizer.WithOut[In, (A, B, C, D, E, F, G)] = new TrailingUnitNormalizer[In] {
+      override type Out = (A, B, C, D, E, F, G)
+    }
+
+    implicit def arity8[In, A, B, C, D, E, F, G, H](implicit ev: In =:= (A, (B, (C, (D, (E, (F, (G, (H, Unit))))))))): TrailingUnitNormalizer.WithOut[In, (A, B, C, D, E, F, G, H)] = new TrailingUnitNormalizer[In] {
+      override type Out = (A, B, C, D, E, F, G, H)
+    }
+
+    implicit def arity9[In, A, B, C, D, E, F, G, H, I](implicit ev: In =:= (A, (B, (C, (D, (E, (F, (G, (H, (I, Unit)))))))))): TrailingUnitNormalizer.WithOut[In, (A, B, C, D, E, F, G, H, I)] = new TrailingUnitNormalizer[In] {
+      override type Out = (A, B, C, D, E, F, G, H, I)
+    }
+
+    implicit def arity10[In, A, B, C, D, E, F, G, H, I, J](implicit ev: In =:= (A, (B, (C, (D, (E, (F, (G, (H, (I, (J, Unit))))))))))): TrailingUnitNormalizer.WithOut[In, (A, B, C, D, E, F, G, H, I, J)] = new TrailingUnitNormalizer[In] {
+      override type Out = (A, B, C, D, E, F, G, H, I, J)
+    }
+
+    implicit def arity11[In, A, B, C, D, E, F, G, H, I, J, K](implicit ev: In =:= (A, (B, (C, (D, (E, (F, (G, (H, (I, (J, (K, Unit)))))))))))): TrailingUnitNormalizer.WithOut[In, (A, B, C, D, E, F, G, H, I, J, K)] = new TrailingUnitNormalizer[In] {
+      override type Out = (A, B, C, D, E, F, G, H, I, J, K)
+    }
+
+    implicit def arity12[In, A, B, C, D, E, F, G, H, I, J, K, L](implicit ev: In =:= (A, (B, (C, (D, (E, (F, (G, (H, (I, (J, (K, (L, Unit))))))))))))): TrailingUnitNormalizer.WithOut[In, (A, B, C, D, E, F, G, H, I, J, K, L)] = new TrailingUnitNormalizer[In] {
+      override type Out = (A, B, C, D, E, F, G, H, I, J, K, L)
+    }
+
+    implicit def arity13[In, A, B, C, D, E, F, G, H, I, J, K, L, M](implicit ev: In =:= (A, (B, (C, (D, (E, (F, (G, (H, (I, (J, (K, (L, (M, Unit)))))))))))))): TrailingUnitNormalizer.WithOut[In, (A, B, C, D, E, F, G, H, I, J, K, L, M)] = new TrailingUnitNormalizer[In] {
+      override type Out = (A, B, C, D, E, F, G, H, I, J, K, L, M)
+    }
+
+    implicit def arity14[In, A, B, C, D, E, F, G, H, I, J, K, L, M, N](implicit ev: In =:= (A, (B, (C, (D, (E, (F, (G, (H, (I, (J, (K, (L, (M, (N, Unit))))))))))))))): TrailingUnitNormalizer.WithOut[In, (A, B, C, D, E, F, G, H, I, J, K, L, M, N)] = new TrailingUnitNormalizer[In] {
+      override type Out = (A, B, C, D, E, F, G, H, I, J, K, L, M, N)
+    }
+
+    implicit def arity15[In, A, B, C, D, E, F, G, H, I, J, K, L, M, N, O](implicit ev: In =:= (A, (B, (C, (D, (E, (F, (G, (H, (I, (J, (K, (L, (M, (N, (O, Unit)))))))))))))))): TrailingUnitNormalizer.WithOut[In, (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O)] = new TrailingUnitNormalizer[In] {
+      override type Out = (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O)
+    }
+
+    implicit def arity16[In, A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P](implicit ev: In =:= (A, (B, (C, (D, (E, (F, (G, (H, (I, (J, (K, (L, (M, (N, (O, (P, Unit))))))))))))))))): TrailingUnitNormalizer.WithOut[In, (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P)] = new TrailingUnitNormalizer[In] {
+      override type Out = (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P)
+    }
+
+    implicit def arity17[In, A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q](implicit ev: In =:= (A, (B, (C, (D, (E, (F, (G, (H, (I, (J, (K, (L, (M, (N, (O, (P, (Q, Unit)))))))))))))))))): TrailingUnitNormalizer.WithOut[In, (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q)] = new TrailingUnitNormalizer[In] {
+      override type Out = (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q)
+    }
+
+    implicit def arity18[In, A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R](implicit ev: In =:= (A, (B, (C, (D, (E, (F, (G, (H, (I, (J, (K, (L, (M, (N, (O, (P, (Q, (R, Unit))))))))))))))))))): TrailingUnitNormalizer.WithOut[In, (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R)] = new TrailingUnitNormalizer[In] {
+      override type Out = (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R)
+    }
+
+    implicit def arity19[In, A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S](implicit ev: In =:= (A, (B, (C, (D, (E, (F, (G, (H, (I, (J, (K, (L, (M, (N, (O, (P, (Q, (R, (S, Unit)))))))))))))))))))): TrailingUnitNormalizer.WithOut[In, (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S)] = new TrailingUnitNormalizer[In] {
+      override type Out = (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S)
+    }
+
+    implicit def arity20[In, A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T](implicit ev: In =:= (A, (B, (C, (D, (E, (F, (G, (H, (I, (J, (K, (L, (M, (N, (O, (P, (Q, (R, (S, (T, Unit))))))))))))))))))))): TrailingUnitNormalizer.WithOut[In, (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T)] = new TrailingUnitNormalizer[In] {
+      override type Out = (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T)
+    }
+
+    implicit def arity21[In, A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U](implicit ev: In =:= (A, (B, (C, (D, (E, (F, (G, (H, (I, (J, (K, (L, (M, (N, (O, (P, (Q, (R, (S, (T, (U, Unit)))))))))))))))))))))): TrailingUnitNormalizer.WithOut[In, (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U)] = new TrailingUnitNormalizer[In] {
+      override type Out = (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U)
+    }
+
+    implicit def arity22[In, A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V](implicit ev: In =:= (A, (B, (C, (D, (E, (F, (G, (H, (I, (J, (K, (L, (M, (N, (O, (P, (Q, (R, (S, (T, (U, (V, Unit))))))))))))))))))))))): TrailingUnitNormalizer.WithOut[In, (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V)] = new TrailingUnitNormalizer[In] {
+      override type Out = (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V)
+    }
+    // format: on
+  }
+}

--- a/core/jvm/src/main/scala/zio/sql/utils.scala
+++ b/core/jvm/src/main/scala/zio/sql/utils.scala
@@ -3,6 +3,8 @@ package zio.sql
 trait UtilsModule { self =>
   sealed trait TrailingUnitNormalizer[In] {
     type Out
+
+    def apply(in: In): Out
   }
 
   object TrailingUnitNormalizer {
@@ -12,90 +14,133 @@ trait UtilsModule { self =>
     // format: off
     implicit def arity1[In, A](implicit ev: In =:= (A, Unit)) : TrailingUnitNormalizer.WithOut[In, A] = new TrailingUnitNormalizer[In] {
       override type Out = A
+
+      override def apply(in: In): A = in._1
     }
 
     implicit def arity2[In, A, B](implicit ev: In =:= (A, (B, Unit))) : TrailingUnitNormalizer.WithOut[In, (A, B)] = new TrailingUnitNormalizer[In] {
       override type Out = (A, B)
+
+      override def apply(in: In): Out = (in._1, in._2._1)
     }
 
     implicit def arity3[In, A, B, C](implicit ev: In =:= (A, (B, (C, Unit)))) : TrailingUnitNormalizer.WithOut[In, (A, B, C)] = new TrailingUnitNormalizer[In] {
       override type Out = (A, B, C)
+
+      override def apply(in: In): Out = (in._1, in._2._1, in._2._2._1)
     }
 
     implicit def arity4[In, A, B, C, D](implicit ev: In =:= (A, (B, (C, (D, Unit))))) : TrailingUnitNormalizer.WithOut[In, (A, B, C, D)] = new TrailingUnitNormalizer[In] {
       override type Out = (A, B, C, D)
+
+      override def apply(in: In): Out = (in._1, in._2._1, in._2._2._1, in._2._2._2._1)
     }
 
     implicit def arity5[In, A, B, C, D, E](implicit ev: In =:= (A, (B, (C, (D, (E, Unit)))))) : TrailingUnitNormalizer.WithOut[In, (A, B, C, D, E)] = new TrailingUnitNormalizer[In] {
       override type Out = (A, B, C, D, E)
+
+      override def apply(in: In): Out = (in._1, in._2._1, in._2._2._1, in._2._2._2._1, in._2._2._2._2._1)
     }
 
     implicit def arity6[In, A, B, C, D, E, F](implicit ev: In =:= (A, (B, (C, (D, (E, (F, Unit))))))) : TrailingUnitNormalizer.WithOut[In, (A, B, C, D, E, F)] = new TrailingUnitNormalizer[In] {
       override type Out = (A, B, C, D, E, F)
+
+      override def apply(in: In): Out = (in._1, in._2._1, in._2._2._1, in._2._2._2._1, in._2._2._2._2._1,  in._2._2._2._2._2._1)
     }
 
     implicit def arity7[In, A, B, C, D, E, F, G](implicit ev: In =:= (A, (B, (C, (D, (E, (F, (G, Unit)))))))): TrailingUnitNormalizer.WithOut[In, (A, B, C, D, E, F, G)] = new TrailingUnitNormalizer[In] {
       override type Out = (A, B, C, D, E, F, G)
+
+      override def apply(in: In): Out = (in._1, in._2._1, in._2._2._1, in._2._2._2._1, in._2._2._2._2._1, in._2._2._2._2._2._1, in._2._2._2._2._2._2._1)
     }
 
     implicit def arity8[In, A, B, C, D, E, F, G, H](implicit ev: In =:= (A, (B, (C, (D, (E, (F, (G, (H, Unit))))))))): TrailingUnitNormalizer.WithOut[In, (A, B, C, D, E, F, G, H)] = new TrailingUnitNormalizer[In] {
       override type Out = (A, B, C, D, E, F, G, H)
+
+      override def apply(in: In): Out = (in._1, in._2._1, in._2._2._1, in._2._2._2._1, in._2._2._2._2._1, in._2._2._2._2._2._1, in._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._1)
     }
 
     implicit def arity9[In, A, B, C, D, E, F, G, H, I](implicit ev: In =:= (A, (B, (C, (D, (E, (F, (G, (H, (I, Unit)))))))))): TrailingUnitNormalizer.WithOut[In, (A, B, C, D, E, F, G, H, I)] = new TrailingUnitNormalizer[In] {
       override type Out = (A, B, C, D, E, F, G, H, I)
+
+      override def apply(in: In): Out = (in._1, in._2._1, in._2._2._1, in._2._2._2._1, in._2._2._2._2._1, in._2._2._2._2._2._1, in._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._1)
     }
 
     implicit def arity10[In, A, B, C, D, E, F, G, H, I, J](implicit ev: In =:= (A, (B, (C, (D, (E, (F, (G, (H, (I, (J, Unit))))))))))): TrailingUnitNormalizer.WithOut[In, (A, B, C, D, E, F, G, H, I, J)] = new TrailingUnitNormalizer[In] {
       override type Out = (A, B, C, D, E, F, G, H, I, J)
+
+      override def apply(in: In): Out = (in._1, in._2._1, in._2._2._1, in._2._2._2._1, in._2._2._2._2._1, in._2._2._2._2._2._1, in._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._1)
     }
 
     implicit def arity11[In, A, B, C, D, E, F, G, H, I, J, K](implicit ev: In =:= (A, (B, (C, (D, (E, (F, (G, (H, (I, (J, (K, Unit)))))))))))): TrailingUnitNormalizer.WithOut[In, (A, B, C, D, E, F, G, H, I, J, K)] = new TrailingUnitNormalizer[In] {
       override type Out = (A, B, C, D, E, F, G, H, I, J, K)
+
+      override def apply(in: In): Out = (in._1, in._2._1, in._2._2._1, in._2._2._2._1, in._2._2._2._2._1, in._2._2._2._2._2._1, in._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._1)
     }
 
     implicit def arity12[In, A, B, C, D, E, F, G, H, I, J, K, L](implicit ev: In =:= (A, (B, (C, (D, (E, (F, (G, (H, (I, (J, (K, (L, Unit))))))))))))): TrailingUnitNormalizer.WithOut[In, (A, B, C, D, E, F, G, H, I, J, K, L)] = new TrailingUnitNormalizer[In] {
       override type Out = (A, B, C, D, E, F, G, H, I, J, K, L)
+
+      override def apply(in: In): Out = (in._1, in._2._1, in._2._2._1, in._2._2._2._1, in._2._2._2._2._1, in._2._2._2._2._2._1, in._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._1)
     }
 
     implicit def arity13[In, A, B, C, D, E, F, G, H, I, J, K, L, M](implicit ev: In =:= (A, (B, (C, (D, (E, (F, (G, (H, (I, (J, (K, (L, (M, Unit)))))))))))))): TrailingUnitNormalizer.WithOut[In, (A, B, C, D, E, F, G, H, I, J, K, L, M)] = new TrailingUnitNormalizer[In] {
       override type Out = (A, B, C, D, E, F, G, H, I, J, K, L, M)
+
+      override def apply(in: In): Out = (in._1, in._2._1, in._2._2._1, in._2._2._2._1, in._2._2._2._2._1, in._2._2._2._2._2._1, in._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._1)
     }
 
     implicit def arity14[In, A, B, C, D, E, F, G, H, I, J, K, L, M, N](implicit ev: In =:= (A, (B, (C, (D, (E, (F, (G, (H, (I, (J, (K, (L, (M, (N, Unit))))))))))))))): TrailingUnitNormalizer.WithOut[In, (A, B, C, D, E, F, G, H, I, J, K, L, M, N)] = new TrailingUnitNormalizer[In] {
       override type Out = (A, B, C, D, E, F, G, H, I, J, K, L, M, N)
+
+      override def apply(in: In): Out = (in._1, in._2._1, in._2._2._1, in._2._2._2._1, in._2._2._2._2._1, in._2._2._2._2._2._1, in._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._1)
     }
 
     implicit def arity15[In, A, B, C, D, E, F, G, H, I, J, K, L, M, N, O](implicit ev: In =:= (A, (B, (C, (D, (E, (F, (G, (H, (I, (J, (K, (L, (M, (N, (O, Unit)))))))))))))))): TrailingUnitNormalizer.WithOut[In, (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O)] = new TrailingUnitNormalizer[In] {
       override type Out = (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O)
+
+      override def apply(in: In): Out = (in._1, in._2._1, in._2._2._1, in._2._2._2._1, in._2._2._2._2._1, in._2._2._2._2._2._1, in._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._2._1)
     }
 
     implicit def arity16[In, A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P](implicit ev: In =:= (A, (B, (C, (D, (E, (F, (G, (H, (I, (J, (K, (L, (M, (N, (O, (P, Unit))))))))))))))))): TrailingUnitNormalizer.WithOut[In, (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P)] = new TrailingUnitNormalizer[In] {
       override type Out = (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P)
+
+      override def apply(in: In): Out = (in._1, in._2._1, in._2._2._1, in._2._2._2._1, in._2._2._2._2._1, in._2._2._2._2._2._1, in._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._1)
     }
 
     implicit def arity17[In, A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q](implicit ev: In =:= (A, (B, (C, (D, (E, (F, (G, (H, (I, (J, (K, (L, (M, (N, (O, (P, (Q, Unit)))))))))))))))))): TrailingUnitNormalizer.WithOut[In, (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q)] = new TrailingUnitNormalizer[In] {
       override type Out = (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q)
+
+      override def apply(in: In): Out = (in._1, in._2._1, in._2._2._1, in._2._2._2._1, in._2._2._2._2._1, in._2._2._2._2._2._1, in._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._1)
     }
 
     implicit def arity18[In, A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R](implicit ev: In =:= (A, (B, (C, (D, (E, (F, (G, (H, (I, (J, (K, (L, (M, (N, (O, (P, (Q, (R, Unit))))))))))))))))))): TrailingUnitNormalizer.WithOut[In, (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R)] = new TrailingUnitNormalizer[In] {
       override type Out = (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R)
+
+      override def apply(in: In): Out = (in._1, in._2._1, in._2._2._1, in._2._2._2._1, in._2._2._2._2._1, in._2._2._2._2._2._1, in._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._1)
     }
 
     implicit def arity19[In, A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S](implicit ev: In =:= (A, (B, (C, (D, (E, (F, (G, (H, (I, (J, (K, (L, (M, (N, (O, (P, (Q, (R, (S, Unit)))))))))))))))))))): TrailingUnitNormalizer.WithOut[In, (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S)] = new TrailingUnitNormalizer[In] {
       override type Out = (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S)
+override def apply(in: In): Out = (in._1, in._2._1, in._2._2._1, in._2._2._2._1, in._2._2._2._2._1, in._2._2._2._2._2._1, in._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._1)
     }
 
     implicit def arity20[In, A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T](implicit ev: In =:= (A, (B, (C, (D, (E, (F, (G, (H, (I, (J, (K, (L, (M, (N, (O, (P, (Q, (R, (S, (T, Unit))))))))))))))))))))): TrailingUnitNormalizer.WithOut[In, (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T)] = new TrailingUnitNormalizer[In] {
       override type Out = (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T)
+
+      override def apply(in: In): Out = (in._1, in._2._1, in._2._2._1, in._2._2._2._1, in._2._2._2._2._1, in._2._2._2._2._2._1, in._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._1)
     }
 
     implicit def arity21[In, A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U](implicit ev: In =:= (A, (B, (C, (D, (E, (F, (G, (H, (I, (J, (K, (L, (M, (N, (O, (P, (Q, (R, (S, (T, (U, Unit)))))))))))))))))))))): TrailingUnitNormalizer.WithOut[In, (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U)] = new TrailingUnitNormalizer[In] {
       override type Out = (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U)
+
+      override def apply(in: In): Out = (in._1, in._2._1, in._2._2._1, in._2._2._2._1, in._2._2._2._2._1, in._2._2._2._2._2._1, in._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._1)
     }
 
     implicit def arity22[In, A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V](implicit ev: In =:= (A, (B, (C, (D, (E, (F, (G, (H, (I, (J, (K, (L, (M, (N, (O, (P, (Q, (R, (S, (T, (U, (V, Unit))))))))))))))))))))))): TrailingUnitNormalizer.WithOut[In, (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V)] = new TrailingUnitNormalizer[In] {
       override type Out = (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V)
+
+      override def apply(in: In): Out = (in._1, in._2._1, in._2._2._1, in._2._2._2._1, in._2._2._2._2._1, in._2._2._2._2._2._1, in._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._1, in._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._2._1)
     }
     // format: on
   }

--- a/core/jvm/src/test/scala/zio/sql/GroupByHavingSpec.scala
+++ b/core/jvm/src/test/scala/zio/sql/GroupByHavingSpec.scala
@@ -37,7 +37,7 @@ object AggregatedProductSchema {
   val id :*: name :*: amount :*: price :*: _ = productTable.columns
 
   val orderValue =
-    select(Arbitrary(name) ++ Sum(price))
+    select(name ++ Sum(price))
       .from(productTable)
       .groupBy(name)
       .having(Sum(price) > 10)

--- a/core/jvm/src/test/scala/zio/sql/GroupByHavingSpec.scala
+++ b/core/jvm/src/test/scala/zio/sql/GroupByHavingSpec.scala
@@ -34,7 +34,7 @@ object AggregatedProductSchema {
       double("price")
   ).table("product")
 
-  val id :*: name :*: amount :*: price :*: _ = productTable.columns
+  val (id, name, amount, price) = productTable.columns
 
   val orderValue =
     select(name ++ Sum(price))

--- a/core/jvm/src/test/scala/zio/sql/ProductSchema.scala
+++ b/core/jvm/src/test/scala/zio/sql/ProductSchema.scala
@@ -22,7 +22,7 @@ object ProductSchema {
       boolean("deleted")
   ).table("product")
 
-  val id :*: lastUpdated :*: name :*: baseAmount :*: finalAmount :*: deleted :*: _ = productTable.columns
+  val (id, lastUpdated, name, baseAmount, finalAmount, deleted) = productTable.columns
 
   val selectAll = select(id ++ lastUpdated ++ baseAmount ++ deleted) from productTable
 }

--- a/core/jvm/src/test/scala/zio/sql/TestBasicSelectSpec.scala
+++ b/core/jvm/src/test/scala/zio/sql/TestBasicSelectSpec.scala
@@ -16,7 +16,7 @@ object TestBasicSelect {
     val userTable =
       (string("user_id") ++ localDate("dob") ++ string("first_name") ++ string("last_name")).table("users")
 
-    val userId :*: dob :*: fName :*: lName :*: _ = userTable.columns
+    val (userId, dob, fName, lName) = userTable.columns
 
     //todo this should compile using column names defined in the table
     val basicSelect = select(fName ++ lName) from userTable

--- a/examples/src/main/scala/Example1.scala
+++ b/examples/src/main/scala/Example1.scala
@@ -38,8 +38,6 @@ object Example1 extends Sql {
     select((age as "age") ++ (age2 as "age2"))
       .from(table.join(table2).on(name === name2))
 
-  val xx = (Arbitrary(age) as "age") ++ (Count(1) as "count")
-
   val aggregated =
     select((Arbitrary(age) as "age") ++ (Count(1) as "count"))
       .from(table)
@@ -59,5 +57,10 @@ object Example1 extends Sql {
 
   val query = select(fkCustomerId ++ Count(orderId))
           .from(orders)
-          .groupBy(fkCustomerId)
+          .groupBy(fkCustomerId, orderDate)
+
+  //TODO remove - just to test group by / having
+  def test[F, A, B](expr: Expr[F,A, B])(implicit in: Features.IsPartiallyAggregated[F]) : in.Unaggregated = ???
+  def test2[F, A, B <: SelectionSet[A]](selection: Selection[F, A, B])(implicit in: Features.IsPartiallyAggregated[F]) : in.Unaggregated = ???
+
 }

--- a/examples/src/main/scala/Example1.scala
+++ b/examples/src/main/scala/Example1.scala
@@ -114,6 +114,6 @@ object Example1 extends Sql {
     value3: Value[F3]
   )                                                                                    = ???
 
-  def test3[Out](read: Read[Out])(implicit in: TrailingUnitNormalizer[Out]) : in.Out = ???
+  def test3[Out](read: Read[Out])(implicit in: TrailingUnitNormalizer[Out]): in.Out = ???
 
 }

--- a/examples/src/main/scala/Example1.scala
+++ b/examples/src/main/scala/Example1.scala
@@ -32,14 +32,14 @@ object Example1 extends Sql {
       .offset(1000)
       .orderBy(age.descending)
 
-  val tt =    ((age + 2) as "age")
+  val tt = ((age + 2) as "age")
 
   val joined =
     select((age as "age") ++ (age2 as "age2"))
       .from(table.join(table2).on(name === name2))
 
   val aggregated =
-    select((Arbitrary(age) as "age") ++ (Count(1) as "count"))
+    select((age as "age") ++ (Count(1) as "count"))
       .from(table)
       .groupBy(age)
 
@@ -56,11 +56,62 @@ object Example1 extends Sql {
   val orderId :*: fkCustomerId :*: orderDate :*: _ = orders.columns
 
   val query = select(fkCustomerId ++ Count(orderId))
-          .from(orders)
-          .groupBy(fkCustomerId, orderDate)
+    .from(orders)
+    .groupBy(fkCustomerId, orderDate)
 
   //TODO remove - just to test group by / having
-  def test[F, A, B](expr: Expr[F,A, B])(implicit in: Features.IsPartiallyAggregated[F]) : in.Unaggregated = ???
-  def test2[F, A, B <: SelectionSet[A]](selection: Selection[F, A, B])(implicit in: Features.IsPartiallyAggregated[F]) : in.Unaggregated = ???
+  def test[F, A, B](expr: Expr[F, A, B])(implicit in: Features.IsPartiallyAggregated[F]): in.Unaggregated = ???
+  def test2[F, A, B <: SelectionSet[A]](selection: Selection[F, A, B])(implicit
+    in: Features.IsPartiallyAggregated[F]
+  ): in.Unaggregated                                                                                      = ???
+
+  //HAVING OK
+
+  // select(fkCustomerId)
+  //   .from(orders)
+  //   .groupBy(fkCustomerId)
+  //   .having(Count(orderId) > 4)
+
+  // select(Count(orderId))
+  //   .from(orders)
+  //   .having(Count(orderId) > 26)
+
+  // select(Count(orderId))
+  //   .from(orders)
+  //   .groupBy(fkCustomerId)
+  //   .having(Count(orderId) > 4)
+
+  // select(Count(id), customerId)
+  //   .from(orders)
+  //   .groupBy(fkCustomerId)
+  //   .having(Count(orderId) > 4)
+
+  //HAVING FAIL
+
+  // select(fkCustomerId)
+  //   .from(orders)
+  //   .having(Count(orderId) > 4)
+
+  //RESTRICTIONS
+  // 1. Having needs to be aggregated
+  // 2. fully agregated expr do not need Group By
+
+  type Value[_]
+
+  sealed trait SomeTypeclass[F]
+
+  object SomeTypeclass {
+    //instances
+  }
+
+  def test(values: Value[_]*) = ???
+
+  def test[F1: SomeTypeclass](value1: Value[F1])                                       = ???
+  def test[F1: SomeTypeclass, F2: SomeTypeclass](value1: Value[F1], value2: Value[F2]) = ???
+  def test[F1: SomeTypeclass, F2: SomeTypeclass, F3: SomeTypeclass](
+    value1: Value[F1],
+    value2: Value[F2],
+    value3: Value[F3]
+  )                                                                                    = ???
 
 }

--- a/examples/src/main/scala/Example1.scala
+++ b/examples/src/main/scala/Example1.scala
@@ -114,4 +114,6 @@ object Example1 extends Sql {
     value3: Value[F3]
   )                                                                                    = ???
 
+  def test3[Out](read: Read[Out])(implicit in: TrailingUnitNormalizer[Out]) : in.Out = ???
+
 }

--- a/examples/src/main/scala/Example1.scala
+++ b/examples/src/main/scala/Example1.scala
@@ -18,9 +18,9 @@ object Example1 extends Sql {
 
   val table2 = columnSet.table("person2")
 
-  val age :*: name :*: _ = table.columns
+  val (age, name) = table.columns
 
-  val age2 :*: name2 :*: _ = table2.columns
+  val (age2, name2) = table2.columns
 
   import FunctionDef._
   import AggregationDef._
@@ -53,7 +53,8 @@ object Example1 extends Sql {
 
   val orders = (uuid("id") ++ uuid("customer_id") ++ localDate("order_date")).table("orders")
 
-  val orderId :*: fkCustomerId :*: orderDate :*: _ = orders.columns
+  // val orderId :*: fkCustomerId :*: orderDate :*: _ = orders.columns
+  val (orderId, fkCustomerId, orderDate) = orders.columns
 
   val query = select(fkCustomerId ++ Count(orderId))
     .from(orders)

--- a/examples/src/main/scala/Example1.scala
+++ b/examples/src/main/scala/Example1.scala
@@ -56,6 +56,11 @@ object Example1 extends Sql {
   // val orderId :*: fkCustomerId :*: orderDate :*: _ = orders.columns
   val (orderId, fkCustomerId, orderDate) = orders.columns
 
+  // Selection[Features.Union[Features.Union[Features.Source[String("id")],Features.Source[String("customer_id")]],Features.Source[String("order_date")]],
+  // orders.TableType,
+  // SelectionSet.Cons[orders.TableType,UUID,SelectionSet.Cons[orders.TableType,UUID,SelectionSet.Cons[orders.TableType,LocalDate,SelectionSet.Empty]]]]
+  val xxxx = orderId ++ fkCustomerId ++ orderDate
+
   val query = select(fkCustomerId ++ Count(orderId))
     .from(orders)
     .groupBy(fkCustomerId, orderDate)

--- a/examples/src/main/scala/Example1.scala
+++ b/examples/src/main/scala/Example1.scala
@@ -32,9 +32,13 @@ object Example1 extends Sql {
       .offset(1000)
       .orderBy(age.descending)
 
+  val tt =    ((age + 2) as "age")
+
   val joined =
     select((age as "age") ++ (age2 as "age2"))
       .from(table.join(table2).on(name === name2))
+
+  val xx = (Arbitrary(age) as "age") ++ (Count(1) as "count")
 
   val aggregated =
     select((Arbitrary(age) as "age") ++ (Count(1) as "count"))
@@ -48,4 +52,12 @@ object Example1 extends Sql {
       .set(age, age + 2)
       .set(name, "foo")
       .where(age > 100)
+
+  val orders = (uuid("id") ++ uuid("customer_id") ++ localDate("order_date")).table("orders")
+
+  val orderId :*: fkCustomerId :*: orderDate :*: _ = orders.columns
+
+  val query = select(fkCustomerId ++ Count(orderId))
+          .from(orders)
+          .groupBy(fkCustomerId)
 }

--- a/examples/src/main/scala/Example1.scala
+++ b/examples/src/main/scala/Example1.scala
@@ -53,73 +53,12 @@ object Example1 extends Sql {
 
   val orders = (uuid("id") ++ uuid("customer_id") ++ localDate("order_date")).table("orders")
 
-  // val orderId :*: fkCustomerId :*: orderDate :*: _ = orders.columns
   val (orderId, fkCustomerId, orderDate) = orders.columns
-
-  // Selection[Features.Union[Features.Union[Features.Source[String("id")],Features.Source[String("customer_id")]],Features.Source[String("order_date")]],
-  // orders.TableType,
-  // SelectionSet.Cons[orders.TableType,UUID,SelectionSet.Cons[orders.TableType,UUID,SelectionSet.Cons[orders.TableType,LocalDate,SelectionSet.Empty]]]]
-  val xxxx = orderId ++ fkCustomerId ++ orderDate
 
   val query = select(fkCustomerId ++ Count(orderId))
     .from(orders)
     .groupBy(fkCustomerId, orderDate)
 
-  //TODO remove - just to test group by / having
-  def test[F, A, B](expr: Expr[F, A, B])(implicit in: Features.IsPartiallyAggregated[F]): in.Unaggregated = ???
-  def test2[F, A, B <: SelectionSet[A]](selection: Selection[F, A, B])(implicit
-    in: Features.IsPartiallyAggregated[F]
-  ): in.Unaggregated                                                                                      = ???
-
-  //HAVING OK
-
-  // select(fkCustomerId)
-  //   .from(orders)
-  //   .groupBy(fkCustomerId)
-  //   .having(Count(orderId) > 4)
-
-  // select(Count(orderId))
-  //   .from(orders)
-  //   .having(Count(orderId) > 26)
-
-  // select(Count(orderId))
-  //   .from(orders)
-  //   .groupBy(fkCustomerId)
-  //   .having(Count(orderId) > 4)
-
-  // select(Count(id), customerId)
-  //   .from(orders)
-  //   .groupBy(fkCustomerId)
-  //   .having(Count(orderId) > 4)
-
-  //HAVING FAIL
-
-  // select(fkCustomerId)
-  //   .from(orders)
-  //   .having(Count(orderId) > 4)
-
-  //RESTRICTIONS
-  // 1. Having needs to be aggregated
-  // 2. fully agregated expr do not need Group By
-
-  type Value[_]
-
-  sealed trait SomeTypeclass[F]
-
-  object SomeTypeclass {
-    //instances
-  }
-
-  def test(values: Value[_]*) = ???
-
-  def test[F1: SomeTypeclass](value1: Value[F1])                                       = ???
-  def test[F1: SomeTypeclass, F2: SomeTypeclass](value1: Value[F1], value2: Value[F2]) = ???
-  def test[F1: SomeTypeclass, F2: SomeTypeclass, F3: SomeTypeclass](
-    value1: Value[F1],
-    value2: Value[F2],
-    value3: Value[F3]
-  )                                                                                    = ???
-
-  def test3[Out](read: Read[Out])(implicit in: TrailingUnitNormalizer[Out]): in.Out = ???
-
+  val e = select(Count(orderId) ++ Count(orderId))
+    .from(orders)
 }

--- a/examples/src/main/scala/ShopSchema.scala
+++ b/examples/src/main/scala/ShopSchema.scala
@@ -6,24 +6,24 @@ trait ShopSchema extends Jdbc { self =>
   object Users         {
     val users = (uuid("id") ++ localDate("dob") ++ string("first_name") ++ string("last_name")).table("users")
 
-    val userId :*: dob :*: fName :*: lName :*: _ = users.columns
+    val (userId, dob, fName, lName) = users.columns
   }
   object Orders        {
     val orders = (uuid("id") ++ uuid("usr_id") ++ localDate("order_date")).table("orders")
 
-    val orderId :*: fkUserId :*: orderDate :*: _ = orders.columns
+    val (orderId, fkUserId, orderDate) = orders.columns
   }
   object Products      {
     val products =
       (int("id") ++ string("name") ++ string("description") ++ string("image_url")).table("products")
 
-    val productId :*: description :*: imageURL :*: _ = products.columns
+    val (productId, name, description, imageURL) = products.columns
   }
   object ProductPrices {
     val productPrices =
       (int("product_id") ++ offsetDateTime("effective") ++ bigDecimal("price")).table("product_prices")
 
-    val fkProductId :*: effective :*: price :*: _ = productPrices.columns
+    val (fkProductId, effective, price) = productPrices.columns
   }
 
   object OrderDetails {
@@ -33,6 +33,6 @@ trait ShopSchema extends Jdbc { self =>
           "order_details"
         ) //todo fix #3 quantity should be int, unit price should be bigDecimal, numeric operators only support double ATM.
 
-    val fkOrderId :*: fkProductId :*: quantity :*: unitPrice :*: _ = orderDetails.columns
+    val (fkOrderId, fkProductId, quantity, unitPrice) = orderDetails.columns
   }
 }

--- a/examples/src/main/scala/zio/sql/Examples.scala
+++ b/examples/src/main/scala/zio/sql/Examples.scala
@@ -55,9 +55,9 @@ object Examples extends App with ShopSchema with SqlServerModule {
 
   val orderValues =
     select(
-      (Arbitrary(userId)) ++
-        (Arbitrary(fName)) ++
-        (Arbitrary(lName)) ++
+      userId ++
+        fName ++
+        lName ++
         (Sum(quantity * unitPrice) as "total_spend") ++
         Sum(Abs(quantity))
     )
@@ -68,7 +68,7 @@ object Examples extends App with ShopSchema with SqlServerModule {
           .leftOuter(orderDetails)
           .on(orderId === fkOrderId)
       )
-      .groupBy(userId, fName /*, lName */ ) //shouldn't compile without lName todo fix #38
+      .groupBy(userId, fName, lName)
   println(renderRead(orderValues))
 
   import scala.language.postfixOps

--- a/jdbc/src/main/scala/zio/sql/ConnectionPool.scala
+++ b/jdbc/src/main/scala/zio/sql/ConnectionPool.scala
@@ -11,7 +11,7 @@ import zio.clock._
 trait ConnectionPool {
 
   /**
-   * Retrieves a JDBC [[java.sql.Connection]] as a [[zio.Managed]] resource.
+   * Retrieves a JDBC java.sql.Connection as a [[zio.Managed]] resource.
    * The managed resource will safely acquire and release the connection, and
    * may be interrupted or timed out if necessary.
    */

--- a/jdbc/src/main/scala/zio/sql/JdbcInternalModule.scala
+++ b/jdbc/src/main/scala/zio/sql/JdbcInternalModule.scala
@@ -122,17 +122,41 @@ trait JdbcInternalModule { self: Jdbc =>
     resultSet: ResultSet,
     schema: Vector[(TypeTag[_], Int)]
   ): Either[DecodingError, A] = {
-    val result: Either[DecodingError, Any] = Right(())
+
+    val result: Either[DecodingError, List[Any]] = Right(List())
 
     schema
       .foldRight(result) {
-        case (_, err @ Left(_))            => err // TODO: Accumulate errors
+        case (_, err@Left(_)) => err // TODO: Accumulate errors
         case ((typeTag, index), Right(vs)) =>
           extractColumn(Left(index), resultSet, typeTag) match {
             case Left(err) => Left(err)
-            case Right(v)  => Right((v, vs))
+            case Right(v) => Right(v :: vs)
           }
-      }
-      .map(_.asInstanceOf[A])
+      }.map {
+      case List(a) => (a)
+      case List(a, b) => (a, b)
+      case List(a, b, c) => (a, b, c)
+      case List(a, b, c, d) => (a, b, c, d)
+      case List(a, b, c, d, e) => (a, b, c, d, e)
+      case List(a, b, c, d, e, f) => (a, b, c, d, e, f)
+      case List(a, b, c, d, e, f, g) => (a, b, c, d, e, f, g)
+      case List(a, b, c, d, e, f, g, h) => (a, b, c, d, e, f, g, h)
+      case List(a, b, c, d, e, f, g, h, i) => (a, b, c, d, e, f, g, h, i)
+      case List(a, b, c, d, e, f, g, h, i, j) => (a, b, c, d, e, f, g, h, i, j)
+      case List(a, b, c, d, e, f, g, h, i, j, k) => (a, b, c, d, e, f, g, h, i, j, k)
+      case List(a, b, c, d, e, f, g, h, i, j, k, l) => (a, b, c, d, e, f, g, h, i, j, k, l)
+      case List(a, b, c, d, e, f, g, h, i, j, k, l, m) => (a, b, c, d, e, f, g, h, i, j, k, l, m)
+      case List(a, b, c, d, e, f, g, h, i, j, k, l, m, n) => (a, b, c, d, e, f, g, h, i, j, k, l, m, n)
+      case List(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o) => (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o)
+      case List(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p) => (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p)
+      case List(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q) => (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q)
+      case List(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r) => (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r)
+      case List(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s) => (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s)
+      case List(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t) => (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t)
+      case List(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u) => (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u)
+      case List(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v) => (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v)
+      case _ => ()
+    }.map(_.asInstanceOf[A])
   }
 }

--- a/jdbc/src/main/scala/zio/sql/JdbcInternalModule.scala
+++ b/jdbc/src/main/scala/zio/sql/JdbcInternalModule.scala
@@ -110,8 +110,6 @@ trait JdbcInternalModule { self: Jdbc =>
 
   private[sql] def getColumns(read: Read[_]): Vector[TypeTag[_]] =
     read match {
-      case Read.Mapped(read, _) => getColumns(read)
-
       case Read.Subselect(selection, _, _, _, _, _, _, _) =>
         selection.value.selectionsUntyped.toVector.map(_.asInstanceOf[ColumnSelection[_, _]]).map {
           case t @ ColumnSelection.Constant(_, _) => t.typeTag
@@ -121,12 +119,11 @@ trait JdbcInternalModule { self: Jdbc =>
       case v @ Read.Literal(_)                            => scala.collection.immutable.Vector(v.typeTag)
     }
 
-  private[sql] def unsafeExtractRow[A](
+   private[sql] def unsafeExtractRow[A](
     resultSet: ResultSet,
     schema: Vector[(TypeTag[_], Int)]
   ): Either[DecodingError, A] = {
-
-    val result: Either[DecodingError, List[Any]] = Right(List())
+    val result: Either[DecodingError, Any] = Right(())
 
     schema
       .foldRight(result) {
@@ -134,39 +131,8 @@ trait JdbcInternalModule { self: Jdbc =>
         case ((typeTag, index), Right(vs)) =>
           extractColumn(index, resultSet, typeTag) match {
             case Left(err) => Left(err)
-            case Right(v)  => Right(v :: vs)
+            case Right(v)  => Right((v, vs))
           }
-      }
-      .map {
-        case List(a)                                                                => (a)
-        case List(a, b)                                                             => (a, b)
-        case List(a, b, c)                                                          => (a, b, c)
-        case List(a, b, c, d)                                                       => (a, b, c, d)
-        case List(a, b, c, d, e)                                                    => (a, b, c, d, e)
-        case List(a, b, c, d, e, f)                                                 => (a, b, c, d, e, f)
-        case List(a, b, c, d, e, f, g)                                              => (a, b, c, d, e, f, g)
-        case List(a, b, c, d, e, f, g, h)                                           => (a, b, c, d, e, f, g, h)
-        case List(a, b, c, d, e, f, g, h, i)                                        => (a, b, c, d, e, f, g, h, i)
-        case List(a, b, c, d, e, f, g, h, i, j)                                     => (a, b, c, d, e, f, g, h, i, j)
-        case List(a, b, c, d, e, f, g, h, i, j, k)                                  => (a, b, c, d, e, f, g, h, i, j, k)
-        case List(a, b, c, d, e, f, g, h, i, j, k, l)                               => (a, b, c, d, e, f, g, h, i, j, k, l)
-        case List(a, b, c, d, e, f, g, h, i, j, k, l, m)                            => (a, b, c, d, e, f, g, h, i, j, k, l, m)
-        case List(a, b, c, d, e, f, g, h, i, j, k, l, m, n)                         => (a, b, c, d, e, f, g, h, i, j, k, l, m, n)
-        case List(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o)                      => (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o)
-        case List(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p)                   => (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p)
-        case List(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q)                =>
-          (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q)
-        case List(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r)             =>
-          (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r)
-        case List(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s)          =>
-          (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s)
-        case List(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t)       =>
-          (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t)
-        case List(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u)    =>
-          (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u)
-        case List(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v) =>
-          (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v)
-        case _                                                                      => ()
       }
       .map(_.asInstanceOf[A])
   }

--- a/jdbc/src/main/scala/zio/sql/JdbcInternalModule.scala
+++ b/jdbc/src/main/scala/zio/sql/JdbcInternalModule.scala
@@ -6,9 +6,9 @@ import java.time.{ OffsetDateTime, OffsetTime, ZoneId, ZoneOffset }
 import zio.Chunk
 
 trait JdbcInternalModule { self: Jdbc =>
-  // TODO: Only support indexes!
+
   private[sql] def extractColumn[A](
-    column: Either[Int, String],
+    columnIndex: Int,
     resultSet: ResultSet,
     typeTag: TypeTag[A],
     nonNull: Boolean = true
@@ -17,91 +17,94 @@ trait JdbcInternalModule { self: Jdbc =>
 
     val metaData = resultSet.getMetaData()
 
-    def tryDecode[A](decoder: => A)(implicit expectedType: TypeTag[A]): Either[DecodingError, A] =
+    def tryDecode[A](decoder: => Option[A])(implicit expectedType: TypeTag[A]): Either[DecodingError, A] =
       if (resultSet.isClosed()) Left(DecodingError.Closed)
       else {
-        val columnExists =
-          column.fold(
-            index => index >= 1 || index <= metaData.getColumnCount(),
-            name =>
-              try {
-                val _ = resultSet.findColumn(name)
-                true
-              } catch { case _: SQLException => false }
-          )
+        val columnExists = columnIndex >= 1 || columnIndex <= metaData.getColumnCount()
 
-        if (!columnExists) Left(DecodingError.MissingColumn(column))
+        if (!columnExists) Left(DecodingError.MissingColumn(columnIndex))
         else
           try {
             val value = decoder
 
-            if (value == null && nonNull) Left(DecodingError.UnexpectedNull(column))
-            else Right(value)
+            value match {
+              case Some(value) => Right(value)
+              case None        =>
+                //TODO following would not be sound - e.g. by outer join any column can be null
+                // if (nonNull)
+                //   Left(DecodingError.UnexpectedNull(column))
+                // else
+                Right(null.asInstanceOf[A])
+            }
           } catch {
             case _: SQLException =>
-              lazy val columnNames = (1 to metaData.getColumnCount()).toVector.map(metaData.getColumnName(_))
-              val columnIndex      = column.fold(index => index, name => columnNames.indexOf(name) + 1)
-
               Left(DecodingError.UnexpectedType(expectedType, metaData.getColumnType(columnIndex)))
           }
       }
 
     typeTag match {
-      case TBigDecimal         => tryDecode[BigDecimal](column.fold(resultSet.getBigDecimal(_), resultSet.getBigDecimal(_)))
-      case TBoolean            => tryDecode[Boolean](column.fold(resultSet.getBoolean(_), resultSet.getBoolean(_)))
-      case TByte               => tryDecode[Byte](column.fold(resultSet.getByte(_), resultSet.getByte(_)))
+
+      case TBigDecimal         =>
+        // could not do tryDecode[BigDecimal](Option(resultSet.getBigDecimal(columnIndex))) because of
+        // suspicious application of an implicit view (math.this.BigDecimal.javaBigDecimal2bigDecimal) in the argument to Option.apply
+        val result = resultSet.getBigDecimal(columnIndex)
+        if (result == null)
+          Right(null.asInstanceOf[A])
+        else {
+          Right(BigDecimal.javaBigDecimal2bigDecimal(result).asInstanceOf[A])
+        }
+      case TBoolean            => tryDecode[Boolean](Option(resultSet.getBoolean(columnIndex)))
+      case TByte               => tryDecode[Byte](Option(resultSet.getByte(columnIndex)))
       case TByteArray          =>
-        tryDecode[Chunk[Byte]](Chunk.fromArray(column.fold(resultSet.getBytes(_), resultSet.getBytes(_))))
-      case TChar               => tryDecode[Char](column.fold(resultSet.getString(_), resultSet.getString(_)).charAt(0))
-      case TDouble             => tryDecode[Double](column.fold(resultSet.getDouble(_), resultSet.getDouble(_)))
-      case TFloat              => tryDecode[Float](column.fold(resultSet.getFloat(_), resultSet.getFloat(_)))
+        tryDecode[Chunk[Byte]](Option(resultSet.getBytes(columnIndex)).map(Chunk.fromArray(_)))
+      case TChar               => tryDecode[Char](Option(resultSet.getString(columnIndex)).map(_.charAt(0)))
+      case TDouble             => tryDecode[Double](Option(resultSet.getDouble(columnIndex)))
+      case TFloat              => tryDecode[Float](Option(resultSet.getFloat(columnIndex)))
       case TInstant            =>
-        tryDecode[java.time.Instant](column.fold(resultSet.getTimestamp(_), resultSet.getTimestamp(_)).toInstant())
-      case TInt                => tryDecode[Int](column.fold(resultSet.getInt(_), resultSet.getInt(_)))
+        tryDecode[java.time.Instant](Option(resultSet.getTimestamp(columnIndex)).map(_.toInstant()))
+      case TInt                => tryDecode[Int](Option(resultSet.getInt(columnIndex)))
       case TLocalDate          =>
         tryDecode[java.time.LocalDate](
-          column.fold(resultSet.getTimestamp(_), resultSet.getTimestamp(_)).toLocalDateTime().toLocalDate()
+          Option(resultSet.getTimestamp(columnIndex)).map(_.toLocalDateTime().toLocalDate())
         )
       case TLocalDateTime      =>
-        tryDecode[java.time.LocalDateTime](
-          column.fold(resultSet.getTimestamp(_), resultSet.getTimestamp(_)).toLocalDateTime()
-        )
+        tryDecode[java.time.LocalDateTime](Option(resultSet.getTimestamp(columnIndex)).map(_.toLocalDateTime()))
       case TLocalTime          =>
         tryDecode[java.time.LocalTime](
-          column.fold(resultSet.getTimestamp(_), resultSet.getTimestamp(_)).toLocalDateTime().toLocalTime()
+          Option(resultSet.getTimestamp(columnIndex)).map(_.toLocalDateTime().toLocalTime())
         )
-      case TLong               => tryDecode[Long](column.fold(resultSet.getLong(_), resultSet.getLong(_)))
+      case TLong               => tryDecode[Long](Option(resultSet.getLong(columnIndex)))
       case TOffsetDateTime     =>
         tryDecode[OffsetDateTime](
-          column
-            .fold(resultSet.getTimestamp(_), resultSet.getTimestamp(_))
-            .toLocalDateTime()
-            .atOffset(ZoneOffset.UTC)
+          Option(resultSet.getTimestamp(columnIndex)).map(_.toLocalDateTime().atOffset(ZoneOffset.UTC))
         )
       case TOffsetTime         =>
         tryDecode[OffsetTime](
-          column
-            .fold(resultSet.getTime(_), resultSet.getTime(_))
-            .toLocalTime
-            .atOffset(ZoneOffset.UTC)
+          Option(resultSet.getTime(columnIndex)).map(_.toLocalTime.atOffset(ZoneOffset.UTC))
         )
-      case TShort              => tryDecode[Short](column.fold(resultSet.getShort(_), resultSet.getShort(_)))
-      case TString             => tryDecode[String](column.fold(resultSet.getString(_), resultSet.getString(_)))
+      case TShort              => tryDecode[Short](Option(resultSet.getShort(columnIndex)))
+      case TString             => tryDecode[String](Option(resultSet.getString(columnIndex)))
       case TUUID               =>
         tryDecode[java.util.UUID](
-          java.util.UUID.fromString(column.fold(resultSet.getString(_), resultSet.getString(_)))
+          Option(resultSet.getString(columnIndex)).map(java.util.UUID.fromString(_))
         )
       case TZonedDateTime      =>
         //2013-07-15 08:15:23.5+00
         tryDecode[java.time.ZonedDateTime](
-          java.time.ZonedDateTime
-            .ofInstant(
-              column.fold(resultSet.getTimestamp(_), resultSet.getTimestamp(_)).toInstant,
-              ZoneId.of(ZoneOffset.UTC.getId)
+          Option(resultSet.getTimestamp(columnIndex))
+            .map(_.toInstant())
+            .map(instant =>
+              java.time.ZonedDateTime
+                .ofInstant(
+                  instant,
+                  ZoneId.of(ZoneOffset.UTC.getId)
+                )
             )
         )
-      case TDialectSpecific(t) => t.decode(column, resultSet)
-      case t @ Nullable()      => extractColumn(column, resultSet, t.typeTag, false).map(Option(_))
+      case TDialectSpecific(t) => t.decode(columnIndex, resultSet)
+      case t @ Nullable()      =>
+        val _ = nonNull
+        extractColumn(columnIndex, resultSet, t.typeTag, false).map(Option(_))
     }
   }
 
@@ -127,36 +130,44 @@ trait JdbcInternalModule { self: Jdbc =>
 
     schema
       .foldRight(result) {
-        case (_, err@Left(_)) => err // TODO: Accumulate errors
+        case (_, err @ Left(_))            => err // TODO: Accumulate errors
         case ((typeTag, index), Right(vs)) =>
-          extractColumn(Left(index), resultSet, typeTag) match {
+          extractColumn(index, resultSet, typeTag) match {
             case Left(err) => Left(err)
-            case Right(v) => Right(v :: vs)
+            case Right(v)  => Right(v :: vs)
           }
-      }.map {
-      case List(a) => (a)
-      case List(a, b) => (a, b)
-      case List(a, b, c) => (a, b, c)
-      case List(a, b, c, d) => (a, b, c, d)
-      case List(a, b, c, d, e) => (a, b, c, d, e)
-      case List(a, b, c, d, e, f) => (a, b, c, d, e, f)
-      case List(a, b, c, d, e, f, g) => (a, b, c, d, e, f, g)
-      case List(a, b, c, d, e, f, g, h) => (a, b, c, d, e, f, g, h)
-      case List(a, b, c, d, e, f, g, h, i) => (a, b, c, d, e, f, g, h, i)
-      case List(a, b, c, d, e, f, g, h, i, j) => (a, b, c, d, e, f, g, h, i, j)
-      case List(a, b, c, d, e, f, g, h, i, j, k) => (a, b, c, d, e, f, g, h, i, j, k)
-      case List(a, b, c, d, e, f, g, h, i, j, k, l) => (a, b, c, d, e, f, g, h, i, j, k, l)
-      case List(a, b, c, d, e, f, g, h, i, j, k, l, m) => (a, b, c, d, e, f, g, h, i, j, k, l, m)
-      case List(a, b, c, d, e, f, g, h, i, j, k, l, m, n) => (a, b, c, d, e, f, g, h, i, j, k, l, m, n)
-      case List(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o) => (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o)
-      case List(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p) => (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p)
-      case List(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q) => (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q)
-      case List(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r) => (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r)
-      case List(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s) => (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s)
-      case List(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t) => (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t)
-      case List(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u) => (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u)
-      case List(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v) => (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v)
-      case _ => ()
-    }.map(_.asInstanceOf[A])
+      }
+      .map {
+        case List(a)                                                                => (a)
+        case List(a, b)                                                             => (a, b)
+        case List(a, b, c)                                                          => (a, b, c)
+        case List(a, b, c, d)                                                       => (a, b, c, d)
+        case List(a, b, c, d, e)                                                    => (a, b, c, d, e)
+        case List(a, b, c, d, e, f)                                                 => (a, b, c, d, e, f)
+        case List(a, b, c, d, e, f, g)                                              => (a, b, c, d, e, f, g)
+        case List(a, b, c, d, e, f, g, h)                                           => (a, b, c, d, e, f, g, h)
+        case List(a, b, c, d, e, f, g, h, i)                                        => (a, b, c, d, e, f, g, h, i)
+        case List(a, b, c, d, e, f, g, h, i, j)                                     => (a, b, c, d, e, f, g, h, i, j)
+        case List(a, b, c, d, e, f, g, h, i, j, k)                                  => (a, b, c, d, e, f, g, h, i, j, k)
+        case List(a, b, c, d, e, f, g, h, i, j, k, l)                               => (a, b, c, d, e, f, g, h, i, j, k, l)
+        case List(a, b, c, d, e, f, g, h, i, j, k, l, m)                            => (a, b, c, d, e, f, g, h, i, j, k, l, m)
+        case List(a, b, c, d, e, f, g, h, i, j, k, l, m, n)                         => (a, b, c, d, e, f, g, h, i, j, k, l, m, n)
+        case List(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o)                      => (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o)
+        case List(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p)                   => (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p)
+        case List(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q)                =>
+          (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q)
+        case List(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r)             =>
+          (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r)
+        case List(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s)          =>
+          (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s)
+        case List(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t)       =>
+          (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t)
+        case List(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u)    =>
+          (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u)
+        case List(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v) =>
+          (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v)
+        case _                                                                      => ()
+      }
+      .map(_.asInstanceOf[A])
   }
 }

--- a/jdbc/src/main/scala/zio/sql/JdbcInternalModule.scala
+++ b/jdbc/src/main/scala/zio/sql/JdbcInternalModule.scala
@@ -110,7 +110,7 @@ trait JdbcInternalModule { self: Jdbc =>
 
   private[sql] def getColumns(read: Read[_]): Vector[TypeTag[_]] =
     read match {
-      case Read.Mapped(read, _) => getColumns(read)
+      case Read.Mapped(read, _)                           => getColumns(read)
       case Read.Subselect(selection, _, _, _, _, _, _, _) =>
         selection.value.selectionsUntyped.toVector.map(_.asInstanceOf[ColumnSelection[_, _]]).map {
           case t @ ColumnSelection.Constant(_, _) => t.typeTag
@@ -120,7 +120,7 @@ trait JdbcInternalModule { self: Jdbc =>
       case v @ Read.Literal(_)                            => scala.collection.immutable.Vector(v.typeTag)
     }
 
-   private[sql] def unsafeExtractRow[A](
+  private[sql] def unsafeExtractRow[A](
     resultSet: ResultSet,
     schema: Vector[(TypeTag[_], Int)]
   ): Either[DecodingError, A] = {
@@ -135,7 +135,7 @@ trait JdbcInternalModule { self: Jdbc =>
             case Right(v)  => Right(v :: vs)
           }
       }
-       .map {
+      .map {
         case List(a)                                                                => (a)
         case List(a, b)                                                             => (a, b)
         case List(a, b, c)                                                          => (a, b, c)

--- a/jdbc/src/main/scala/zio/sql/JdbcInternalModule.scala
+++ b/jdbc/src/main/scala/zio/sql/JdbcInternalModule.scala
@@ -109,7 +109,7 @@ trait JdbcInternalModule { self: Jdbc =>
     read match {
       case Read.Mapped(read, _) => getColumns(read)
 
-      case Read.Subselect(selection, _, _, _, _, _, _, _) =>
+      case Read.Subselect(selection, _, _, _, _, _, _, _, _) =>
         selection.value.selectionsUntyped.toVector.map(_.asInstanceOf[ColumnSelection[_, _]]).map {
           case t @ ColumnSelection.Constant(_, _) => t.typeTag
           case t @ ColumnSelection.Computed(_, _) => t.typeTag

--- a/jdbc/src/main/scala/zio/sql/JdbcInternalModule.scala
+++ b/jdbc/src/main/scala/zio/sql/JdbcInternalModule.scala
@@ -109,7 +109,7 @@ trait JdbcInternalModule { self: Jdbc =>
     read match {
       case Read.Mapped(read, _) => getColumns(read)
 
-      case Read.Subselect(selection, _, _, _, _, _, _, _, _) =>
+      case Read.Subselect(selection, _, _, _, _, _, _, _) =>
         selection.value.selectionsUntyped.toVector.map(_.asInstanceOf[ColumnSelection[_, _]]).map {
           case t @ ColumnSelection.Constant(_, _) => t.typeTag
           case t @ ColumnSelection.Computed(_, _) => t.typeTag

--- a/jdbc/src/main/scala/zio/sql/JdbcInternalModule.scala
+++ b/jdbc/src/main/scala/zio/sql/JdbcInternalModule.scala
@@ -110,6 +110,7 @@ trait JdbcInternalModule { self: Jdbc =>
 
   private[sql] def getColumns(read: Read[_]): Vector[TypeTag[_]] =
     read match {
+      case Read.Mapped(read, _) => getColumns(read)
       case Read.Subselect(selection, _, _, _, _, _, _, _) =>
         selection.value.selectionsUntyped.toVector.map(_.asInstanceOf[ColumnSelection[_, _]]).map {
           case t @ ColumnSelection.Constant(_, _) => t.typeTag
@@ -123,7 +124,7 @@ trait JdbcInternalModule { self: Jdbc =>
     resultSet: ResultSet,
     schema: Vector[(TypeTag[_], Int)]
   ): Either[DecodingError, A] = {
-    val result: Either[DecodingError, Any] = Right(())
+    val result: Either[DecodingError, List[Any]] = Right(List())
 
     schema
       .foldRight(result) {
@@ -131,8 +132,39 @@ trait JdbcInternalModule { self: Jdbc =>
         case ((typeTag, index), Right(vs)) =>
           extractColumn(index, resultSet, typeTag) match {
             case Left(err) => Left(err)
-            case Right(v)  => Right((v, vs))
+            case Right(v)  => Right(v :: vs)
           }
+      }
+       .map {
+        case List(a)                                                                => (a)
+        case List(a, b)                                                             => (a, b)
+        case List(a, b, c)                                                          => (a, b, c)
+        case List(a, b, c, d)                                                       => (a, b, c, d)
+        case List(a, b, c, d, e)                                                    => (a, b, c, d, e)
+        case List(a, b, c, d, e, f)                                                 => (a, b, c, d, e, f)
+        case List(a, b, c, d, e, f, g)                                              => (a, b, c, d, e, f, g)
+        case List(a, b, c, d, e, f, g, h)                                           => (a, b, c, d, e, f, g, h)
+        case List(a, b, c, d, e, f, g, h, i)                                        => (a, b, c, d, e, f, g, h, i)
+        case List(a, b, c, d, e, f, g, h, i, j)                                     => (a, b, c, d, e, f, g, h, i, j)
+        case List(a, b, c, d, e, f, g, h, i, j, k)                                  => (a, b, c, d, e, f, g, h, i, j, k)
+        case List(a, b, c, d, e, f, g, h, i, j, k, l)                               => (a, b, c, d, e, f, g, h, i, j, k, l)
+        case List(a, b, c, d, e, f, g, h, i, j, k, l, m)                            => (a, b, c, d, e, f, g, h, i, j, k, l, m)
+        case List(a, b, c, d, e, f, g, h, i, j, k, l, m, n)                         => (a, b, c, d, e, f, g, h, i, j, k, l, m, n)
+        case List(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o)                      => (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o)
+        case List(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p)                   => (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p)
+        case List(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q)                =>
+          (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q)
+        case List(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r)             =>
+          (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r)
+        case List(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s)          =>
+          (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s)
+        case List(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t)       =>
+          (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t)
+        case List(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u)    =>
+          (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u)
+        case List(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v) =>
+          (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v)
+        case _                                                                      => ()
       }
       .map(_.asInstanceOf[A])
   }

--- a/jdbc/src/main/scala/zio/sql/SqlDriverLiveModule.scala
+++ b/jdbc/src/main/scala/zio/sql/SqlDriverLiveModule.scala
@@ -14,7 +14,7 @@ trait SqlDriverLiveModule { self: Jdbc =>
 
     def updateOn(update: Update[_], conn: Connection): IO[Exception, Int]
 
-    def readOn[A](read: Read[A], conn: Connection)(implicit in: TrailingUnitNormalizer[A]): Stream[Exception, in.Out]
+    def readOn[A](read: Read[A], conn: Connection): Stream[Exception, A]
 
     def insertOn[A: Schema](insert: Insert[_, A], conn: Connection): IO[Exception, Int]
   }
@@ -46,12 +46,12 @@ trait SqlDriverLiveModule { self: Jdbc =>
 
       }.refineToOrDie[Exception]
 
-    def read[A](read: Read[A])(implicit in: TrailingUnitNormalizer[A]): Stream[Exception, in.Out] =
+    def read[A](read: Read[A]): Stream[Exception, A] =
       ZStream
         .managed(pool.connection)
         .flatMap(readOn(read, _))
 
-    override def readOn[A](read: Read[A], conn: Connection)(implicit in: TrailingUnitNormalizer[A]): Stream[Exception, in.Out] = 
+    override def readOn[A](read: Read[A], conn: Connection): Stream[Exception, A] = 
       Stream.unwrap {
         blocking.effectBlocking {
           val schema = getColumns(read).zipWithIndex.map { case (value, index) =>
@@ -79,7 +79,6 @@ trait SqlDriverLiveModule { self: Jdbc =>
                 } else ZIO.succeed(None)
               }
               .map(read.mapper)
-              .map(a => in.apply(a))
           } else ZStream.empty
 
         }.refineToOrDie[Exception]

--- a/jdbc/src/main/scala/zio/sql/SqlDriverLiveModule.scala
+++ b/jdbc/src/main/scala/zio/sql/SqlDriverLiveModule.scala
@@ -51,7 +51,7 @@ trait SqlDriverLiveModule { self: Jdbc =>
         .managed(pool.connection)
         .flatMap(readOn(read, _))
 
-    override def readOn[A](read: Read[A], conn: Connection): Stream[Exception, A] = 
+    override def readOn[A](read: Read[A], conn: Connection): Stream[Exception, A] =
       Stream.unwrap {
         blocking.effectBlocking {
           val schema = getColumns(read).zipWithIndex.map { case (value, index) =>

--- a/jdbc/src/main/scala/zio/sql/TransactionModule.scala
+++ b/jdbc/src/main/scala/zio/sql/TransactionModule.scala
@@ -5,6 +5,7 @@ import java.sql._
 import zio._
 import zio.blocking.Blocking
 import zio.stream._
+import zio.schema.Schema
 
 trait TransactionModule { self: Jdbc =>
   private[sql] sealed case class Txn(connection: Connection, sqlDriverCore: SqlDriverCore)
@@ -80,6 +81,11 @@ trait TransactionModule { self: Jdbc =>
     def apply(update: self.Update[_]): ZTransaction[Any, Exception, Int] =
       txn.flatMap { case Txn(connection, coreDriver) =>
         ZTransaction.fromEffect(coreDriver.updateOn(update, connection))
+      }
+    
+    def apply[Z: Schema](insert: self.Insert[_, Z]): ZTransaction[Any, Exception, Int] =
+      txn.flatMap { case Txn(connection, coreDriver) =>
+        ZTransaction.fromEffect(coreDriver.insertOn(insert, connection))
       }
 
     def apply(delete: self.Delete[_]): ZTransaction[Any, Exception, Int] =

--- a/jdbc/src/main/scala/zio/sql/TransactionModule.scala
+++ b/jdbc/src/main/scala/zio/sql/TransactionModule.scala
@@ -69,7 +69,7 @@ trait TransactionModule { self: Jdbc =>
   object ZTransaction {
     def apply[A](
       read: self.Read[A]
-    )(implicit in: TrailingUnitNormalizer[A]): ZTransaction[Any, Exception, zio.stream.Stream[Exception, in.Out]] =
+    ): ZTransaction[Any, Exception, zio.stream.Stream[Exception, A]] =
       txn.flatMap { case Txn(connection, coreDriver) =>
         // FIXME: Find a way to NOT load the whole result set into memory at once!!!
         val stream =

--- a/jdbc/src/main/scala/zio/sql/TransactionModule.scala
+++ b/jdbc/src/main/scala/zio/sql/TransactionModule.scala
@@ -82,7 +82,7 @@ trait TransactionModule { self: Jdbc =>
       txn.flatMap { case Txn(connection, coreDriver) =>
         ZTransaction.fromEffect(coreDriver.updateOn(update, connection))
       }
-    
+
     def apply[Z: Schema](insert: self.Insert[_, Z]): ZTransaction[Any, Exception, Int] =
       txn.flatMap { case Txn(connection, coreDriver) =>
         ZTransaction.fromEffect(coreDriver.insertOn(insert, connection))

--- a/jdbc/src/main/scala/zio/sql/TransactionModule.scala
+++ b/jdbc/src/main/scala/zio/sql/TransactionModule.scala
@@ -69,7 +69,7 @@ trait TransactionModule { self: Jdbc =>
   object ZTransaction {
     def apply[A](
       read: self.Read[A]
-    ): ZTransaction[Any, Exception, zio.stream.Stream[Exception, A]] =
+    )(implicit in: TrailingUnitNormalizer[A]): ZTransaction[Any, Exception, zio.stream.Stream[Exception, in.Out]] =
       txn.flatMap { case Txn(connection, coreDriver) =>
         // FIXME: Find a way to NOT load the whole result set into memory at once!!!
         val stream =

--- a/jdbc/src/main/scala/zio/sql/jdbc.scala
+++ b/jdbc/src/main/scala/zio/sql/jdbc.scala
@@ -11,7 +11,7 @@ trait Jdbc extends zio.sql.Sql with TransactionModule with JdbcInternalModule wi
 
     def update(update: Update[_]): IO[Exception, Int]
 
-    def read[A](read: Read[A])(implicit in: TrailingUnitNormalizer[A]): Stream[Exception, in.Out]
+    def read[A](read: Read[A]): Stream[Exception, A]
 
     def transact[R, A](tx: ZTransaction[R, Exception, A]): ZManaged[R, Exception, A]
 
@@ -28,7 +28,7 @@ trait Jdbc extends zio.sql.Sql with TransactionModule with JdbcInternalModule wi
   def execute[R <: Has[SqlDriver], A](tx: ZTransaction[R, Exception, A]): ZManaged[R, Exception, A] =
     ZManaged.accessManaged[R](_.get.transact(tx))
 
-  def execute[A](read: Read[A])(implicit in: TrailingUnitNormalizer[A]): ZStream[Has[SqlDriver], Exception, in.Out] =
+  def execute[A](read: Read[A]): ZStream[Has[SqlDriver], Exception, A] =
     ZStream.unwrap(ZIO.access[Has[SqlDriver]](_.get.read(read)))
 
   def execute(delete: Delete[_]): ZIO[Has[SqlDriver], Exception, Int] =

--- a/jdbc/src/main/scala/zio/sql/jdbc.scala
+++ b/jdbc/src/main/scala/zio/sql/jdbc.scala
@@ -11,7 +11,7 @@ trait Jdbc extends zio.sql.Sql with TransactionModule with JdbcInternalModule wi
 
     def update(update: Update[_]): IO[Exception, Int]
 
-    def read[A](read: Read[A]): Stream[Exception, A]
+    def read[A](read: Read[A])(implicit in: TrailingUnitNormalizer[A]): Stream[Exception, in.Out]
 
     def transact[R, A](tx: ZTransaction[R, Exception, A]): ZManaged[R, Exception, A]
 
@@ -28,7 +28,7 @@ trait Jdbc extends zio.sql.Sql with TransactionModule with JdbcInternalModule wi
   def execute[R <: Has[SqlDriver], A](tx: ZTransaction[R, Exception, A]): ZManaged[R, Exception, A] =
     ZManaged.accessManaged[R](_.get.transact(tx))
 
-  def execute[A](read: Read[A]): ZStream[Has[SqlDriver], Exception, A] =
+  def execute[A](read: Read[A])(implicit in: TrailingUnitNormalizer[A]): ZStream[Has[SqlDriver], Exception, in.Out] =
     ZStream.unwrap(ZIO.access[Has[SqlDriver]](_.get.read(read)))
 
   def execute(delete: Delete[_]): ZIO[Has[SqlDriver], Exception, Int] =

--- a/mysql/src/main/scala/zio/sql/mysql/MysqlModule.scala
+++ b/mysql/src/main/scala/zio/sql/mysql/MysqlModule.scala
@@ -82,6 +82,8 @@ trait MysqlModule extends Jdbc { self =>
 
     def renderReadImpl(read: self.Read[_])(implicit render: Renderer): Unit =
       read match {
+        case Read.Mapped(read, _) => renderReadImpl(read)
+
         case read0 @ Read.Subselect(_, _, _, _, _, _, _, _) =>
           object Dummy {
             type F

--- a/mysql/src/main/scala/zio/sql/mysql/MysqlModule.scala
+++ b/mysql/src/main/scala/zio/sql/mysql/MysqlModule.scala
@@ -119,7 +119,7 @@ trait MysqlModule extends Jdbc { self =>
                   render(" HAVING ")
                   renderExpr(havingExpr)
               }
-            case Read.ExprSet.NoExpr    => ()
+            case Read.ExprSet.NoExpr         => ()
           }
           orderByExprs match {
             case _ :: _ =>
@@ -403,15 +403,15 @@ trait MysqlModule extends Jdbc { self =>
 
     private def renderExprList(expr: Read.ExprSet[_])(implicit render: Renderer): Unit =
       expr match {
-        case Read.ExprSet.ExprCons(head, tail) => 
+        case Read.ExprSet.ExprCons(head, tail) =>
           renderExpr(head)
-          tail match {
+          tail.asInstanceOf[Read.ExprSet[_]] match {
             case Read.ExprSet.ExprCons(_, _) =>
               render(", ")
-              renderExprList(tail)
-            case Read.ExprSet.NoExpr    => ()
+              renderExprList(tail.asInstanceOf[Read.ExprSet[_]])
+            case Read.ExprSet.NoExpr         => ()
           }
-        case Read.ExprSet.NoExpr    => ()
+        case Read.ExprSet.NoExpr               => ()
       }
 
     def renderOrderingList(expr: List[Ordering[Expr[_, _, _]]])(implicit render: Renderer): Unit =

--- a/mysql/src/main/scala/zio/sql/mysql/MysqlModule.scala
+++ b/mysql/src/main/scala/zio/sql/mysql/MysqlModule.scala
@@ -16,9 +16,9 @@ trait MysqlModule extends Jdbc { self =>
 
     object MysqlTypeTag {
       implicit case object TYear extends MysqlTypeTag[Year] {
-        override def decode(column: Either[Int, String], resultSet: ResultSet): Either[DecodingError, Year] =
+        override def decode(column: Int, resultSet: ResultSet): Either[DecodingError, Year] =
           scala.util
-            .Try(Year.of(column.fold(resultSet.getByte(_), resultSet.getByte(_)).toInt))
+            .Try(Year.of(resultSet.getByte(column).toInt))
             .fold(
               _ => Left(DecodingError.UnexpectedNull(column)),
               r => Right(r)

--- a/mysql/src/main/scala/zio/sql/mysql/MysqlModule.scala
+++ b/mysql/src/main/scala/zio/sql/mysql/MysqlModule.scala
@@ -85,7 +85,7 @@ trait MysqlModule extends Jdbc { self =>
         case Read.Mapped(read, _) =>
           renderReadImpl(read)
 
-        case read0 @ Read.Subselect(_, _, _, _, _, _, _, _) =>
+        case read0 @ Read.Subselect(_, _, _, _, _, _, _, _, _) =>
           object Dummy {
             type F
             type Repr
@@ -108,10 +108,10 @@ trait MysqlModule extends Jdbc { self =>
               render(" WHERE ")
               renderExpr(whereExpr)
           }
-          groupBy match {
+          groupByExprs match {
             case _ :: _ =>
               render(" GROUP BY ")
-              renderExprList(groupBy)
+              renderExprList(groupByExprs)
 
               havingExpr match {
                 case Expr.Literal(true) => ()
@@ -121,10 +121,10 @@ trait MysqlModule extends Jdbc { self =>
               }
             case Nil    => ()
           }
-          orderBy match {
+          orderByExprs match {
             case _ :: _ =>
               render(" ORDER BY ")
-              renderOrderingList(orderBy)
+              renderOrderingList(orderByExprs)
             case Nil    => ()
           }
           limit match {

--- a/mysql/src/main/scala/zio/sql/mysql/MysqlModule.scala
+++ b/mysql/src/main/scala/zio/sql/mysql/MysqlModule.scala
@@ -82,9 +82,6 @@ trait MysqlModule extends Jdbc { self =>
 
     def renderReadImpl(read: self.Read[_])(implicit render: Renderer): Unit =
       read match {
-        case Read.Mapped(read, _) =>
-          renderReadImpl(read)
-
         case read0 @ Read.Subselect(_, _, _, _, _, _, _, _) =>
           object Dummy {
             type F

--- a/mysql/src/main/scala/zio/sql/mysql/MysqlModule.scala
+++ b/mysql/src/main/scala/zio/sql/mysql/MysqlModule.scala
@@ -85,7 +85,7 @@ trait MysqlModule extends Jdbc { self =>
         case Read.Mapped(read, _) =>
           renderReadImpl(read)
 
-        case read0 @ Read.Subselect(_, _, _, _, _, _, _, _, _) =>
+        case read0 @ Read.Subselect(_, _, _, _, _, _, _, _) =>
           object Dummy {
             type F
             type Repr
@@ -109,7 +109,7 @@ trait MysqlModule extends Jdbc { self =>
               renderExpr(whereExpr)
           }
           groupByExprs match {
-            case _ :: _ =>
+            case Read.ExprSet.ExprCons(_, _) =>
               render(" GROUP BY ")
               renderExprList(groupByExprs)
 
@@ -119,7 +119,7 @@ trait MysqlModule extends Jdbc { self =>
                   render(" HAVING ")
                   renderExpr(havingExpr)
               }
-            case Nil    => ()
+            case Read.ExprSet.NoExpr    => ()
           }
           orderByExprs match {
             case _ :: _ =>
@@ -401,17 +401,17 @@ trait MysqlModule extends Jdbc { self =>
           }
       }
 
-    private def renderExprList(expr: List[Expr[_, _, _]])(implicit render: Renderer): Unit =
+    private def renderExprList(expr: Read.ExprSet[_])(implicit render: Renderer): Unit =
       expr match {
-        case head :: tail =>
+        case Read.ExprSet.ExprCons(head, tail) => 
           renderExpr(head)
           tail match {
-            case _ :: _ =>
+            case Read.ExprSet.ExprCons(_, _) =>
               render(", ")
               renderExprList(tail)
-            case Nil    => ()
+            case Read.ExprSet.NoExpr    => ()
           }
-        case Nil          => ()
+        case Read.ExprSet.NoExpr    => ()
       }
 
     def renderOrderingList(expr: List[Ordering[Expr[_, _, _]]])(implicit render: Renderer): Unit =

--- a/mysql/src/test/scala/zio/sql/mysql/FunctionDefSpec.scala
+++ b/mysql/src/test/scala/zio/sql/mysql/FunctionDefSpec.scala
@@ -16,7 +16,7 @@ object FunctionDefSpec extends MysqlRunnableSpec with ShopSchema {
 
       val expected = "ronald"
 
-      val testResult = execute(query.to(identity))
+      val testResult = execute(query)
 
       val assertion = for {
         r <- testResult.runCollect
@@ -45,7 +45,7 @@ object FunctionDefSpec extends MysqlRunnableSpec with ShopSchema {
 
       val expected = 0.8414709848078965
 
-      val testResult = execute(query.to(identity))
+      val testResult = execute(query)
 
       val assertion = for {
         r <- testResult.runCollect
@@ -58,7 +58,7 @@ object FunctionDefSpec extends MysqlRunnableSpec with ShopSchema {
 
       val expected = 32.0
 
-      val testResult = execute(query.to(identity))
+      val testResult = execute(query)
 
       val assertion = for {
         r <- testResult.runCollect
@@ -71,7 +71,7 @@ object FunctionDefSpec extends MysqlRunnableSpec with ShopSchema {
 
       val expected = 3259397556L
 
-      val testResult = execute(query.to(identity))
+      val testResult = execute(query)
 
       val assertion = for {
         r <- testResult.runCollect
@@ -84,7 +84,7 @@ object FunctionDefSpec extends MysqlRunnableSpec with ShopSchema {
 
       val expected = 180d
 
-      val testResult = execute(query.to(identity))
+      val testResult = execute(query)
 
       val assertion = for {
         r <- testResult.runCollect
@@ -97,7 +97,7 @@ object FunctionDefSpec extends MysqlRunnableSpec with ShopSchema {
 
       val expected = 3d
 
-      val testResult = execute(query.to(identity))
+      val testResult = execute(query)
 
       val assertion = for {
         r <- testResult.runCollect
@@ -110,7 +110,7 @@ object FunctionDefSpec extends MysqlRunnableSpec with ShopSchema {
 
       val expected = 6d
 
-      val testResult = execute(query.to(identity))
+      val testResult = execute(query)
 
       val assertion = for {
         r <- testResult.runCollect
@@ -123,7 +123,7 @@ object FunctionDefSpec extends MysqlRunnableSpec with ShopSchema {
 
       val expected = 40
 
-      val testResult = execute(query.to(identity))
+      val testResult = execute(query)
 
       val assertion = for {
         r <- testResult.runCollect
@@ -136,7 +136,7 @@ object FunctionDefSpec extends MysqlRunnableSpec with ShopSchema {
 
       val expected = 3.141593d
 
-      val testResult = execute(query.to(identity))
+      val testResult = execute(query)
 
       val assertion = for {
         r <- testResult.runCollect

--- a/mysql/src/test/scala/zio/sql/mysql/FunctionDefSpec.scala
+++ b/mysql/src/test/scala/zio/sql/mysql/FunctionDefSpec.scala
@@ -16,7 +16,7 @@ object FunctionDefSpec extends MysqlRunnableSpec with ShopSchema {
 
       val expected = "ronald"
 
-      val testResult = execute(query.to[String, String](identity))
+      val testResult = execute(query.to(identity))
 
       val assertion = for {
         r <- testResult.runCollect
@@ -45,7 +45,7 @@ object FunctionDefSpec extends MysqlRunnableSpec with ShopSchema {
 
       val expected = 0.8414709848078965
 
-      val testResult = execute(query.to[Double, Double](identity))
+      val testResult = execute(query.to(identity))
 
       val assertion = for {
         r <- testResult.runCollect
@@ -58,7 +58,7 @@ object FunctionDefSpec extends MysqlRunnableSpec with ShopSchema {
 
       val expected = 32.0
 
-      val testResult = execute(query.to[Double, Double](identity))
+      val testResult = execute(query.to(identity))
 
       val assertion = for {
         r <- testResult.runCollect
@@ -71,7 +71,7 @@ object FunctionDefSpec extends MysqlRunnableSpec with ShopSchema {
 
       val expected = 3259397556L
 
-      val testResult = execute(query.to[Long, Long](identity))
+      val testResult = execute(query.to(identity))
 
       val assertion = for {
         r <- testResult.runCollect
@@ -84,7 +84,7 @@ object FunctionDefSpec extends MysqlRunnableSpec with ShopSchema {
 
       val expected = 180d
 
-      val testResult = execute(query.to[Double, Double](identity))
+      val testResult = execute(query.to(identity))
 
       val assertion = for {
         r <- testResult.runCollect
@@ -97,7 +97,7 @@ object FunctionDefSpec extends MysqlRunnableSpec with ShopSchema {
 
       val expected = 3d
 
-      val testResult = execute(query.to[Double, Double](identity))
+      val testResult = execute(query.to(identity))
 
       val assertion = for {
         r <- testResult.runCollect
@@ -110,7 +110,7 @@ object FunctionDefSpec extends MysqlRunnableSpec with ShopSchema {
 
       val expected = 6d
 
-      val testResult = execute(query.to[Double, Double](identity))
+      val testResult = execute(query.to(identity))
 
       val assertion = for {
         r <- testResult.runCollect
@@ -123,7 +123,7 @@ object FunctionDefSpec extends MysqlRunnableSpec with ShopSchema {
 
       val expected = 40
 
-      val testResult = execute(query.to[Int, Int](identity))
+      val testResult = execute(query.to(identity))
 
       val assertion = for {
         r <- testResult.runCollect
@@ -136,7 +136,7 @@ object FunctionDefSpec extends MysqlRunnableSpec with ShopSchema {
 
       val expected = 3.141593d
 
-      val testResult = execute(query.to[Double, Double](identity))
+      val testResult = execute(query.to(identity))
 
       val assertion = for {
         r <- testResult.runCollect

--- a/mysql/src/test/scala/zio/sql/mysql/MysqlModuleTest.scala
+++ b/mysql/src/test/scala/zio/sql/mysql/MysqlModuleTest.scala
@@ -57,7 +57,7 @@ object MysqlModuleTest extends MysqlRunnableSpec with ShopSchema {
 
       val testResult = execute(
         query
-          .to[UUID, String, String, LocalDate, Customer] { case row =>
+          .to { case row =>
             Customer(row._1, row._2, row._3, row._4)
           }
       )
@@ -88,7 +88,7 @@ object MysqlModuleTest extends MysqlRunnableSpec with ShopSchema {
 
       val testResult = execute(
         query
-          .to[UUID, String, String, Boolean, LocalDate, Customer] { case row =>
+          .to { case row =>
             Customer(row._1, row._2, row._3, row._4, row._5)
           }
       )
@@ -118,7 +118,7 @@ object MysqlModuleTest extends MysqlRunnableSpec with ShopSchema {
 
       val testResult = execute(
         query
-          .to[UUID, String, String, LocalDate, Customer] { case row =>
+          .to { case row =>
             Customer(row._1, row._2, row._3, row._4)
           }
       )
@@ -162,7 +162,7 @@ object MysqlModuleTest extends MysqlRunnableSpec with ShopSchema {
 
       val result = execute(
         query
-          .to[String, String, LocalDate, Row] { case row =>
+          .to { case row =>
             Row(row._1, row._2, row._3)
           }
       )

--- a/mysql/src/test/scala/zio/sql/mysql/MysqlModuleTest.scala
+++ b/mysql/src/test/scala/zio/sql/mysql/MysqlModuleTest.scala
@@ -56,10 +56,9 @@ object MysqlModuleTest extends MysqlRunnableSpec with ShopSchema {
         )
 
       val testResult = execute(
-        query.to { case row =>
+        query).map { case row =>
           Customer(row._1, row._2, row._3, row._4)
         }
-      )
 
       val assertion = for {
         r <- testResult.runCollect
@@ -86,10 +85,9 @@ object MysqlModuleTest extends MysqlRunnableSpec with ShopSchema {
         )
 
       val testResult = execute(
-        query.to { case row =>
+        query).map { case row =>
           Customer(row._1, row._2, row._3, row._4, row._5)
         }
-      )
 
       val assertion = for {
         r <- testResult.runCollect
@@ -114,11 +112,9 @@ object MysqlModuleTest extends MysqlRunnableSpec with ShopSchema {
           )
         )
 
-      val testResult = execute(
-        query.to { case row =>
+      val testResult = execute(query).map { case row =>
           Customer(row._1, row._2, row._3, row._4)
         }
-      )
 
       val assertion = for {
         r <- testResult.runCollect
@@ -157,11 +153,9 @@ object MysqlModuleTest extends MysqlRunnableSpec with ShopSchema {
         Row("Jose", "Wiggins", LocalDate.parse("2020-01-15"))
       )
 
-      val result = execute(
-        query.to { case row =>
+      val result = execute(query).map { case row =>
           Row(row._1, row._2, row._3)
         }
-      )
 
       val assertion = for {
         r <- result.runCollect

--- a/mysql/src/test/scala/zio/sql/mysql/MysqlModuleTest.scala
+++ b/mysql/src/test/scala/zio/sql/mysql/MysqlModuleTest.scala
@@ -56,10 +56,9 @@ object MysqlModuleTest extends MysqlRunnableSpec with ShopSchema {
         )
 
       val testResult = execute(
-        query
-          .to { case row =>
-            Customer(row._1, row._2, row._3, row._4)
-          }
+        query.to { case row =>
+          Customer(row._1, row._2, row._3, row._4)
+        }
       )
 
       val assertion = for {
@@ -87,10 +86,9 @@ object MysqlModuleTest extends MysqlRunnableSpec with ShopSchema {
         )
 
       val testResult = execute(
-        query
-          .to { case row =>
-            Customer(row._1, row._2, row._3, row._4, row._5)
-          }
+        query.to { case row =>
+          Customer(row._1, row._2, row._3, row._4, row._5)
+        }
       )
 
       val assertion = for {
@@ -117,10 +115,9 @@ object MysqlModuleTest extends MysqlRunnableSpec with ShopSchema {
         )
 
       val testResult = execute(
-        query
-          .to { case row =>
-            Customer(row._1, row._2, row._3, row._4)
-          }
+        query.to { case row =>
+          Customer(row._1, row._2, row._3, row._4)
+        }
       )
 
       val assertion = for {
@@ -161,10 +158,9 @@ object MysqlModuleTest extends MysqlRunnableSpec with ShopSchema {
       )
 
       val result = execute(
-        query
-          .to { case row =>
-            Row(row._1, row._2, row._3)
-          }
+        query.to { case row =>
+          Row(row._1, row._2, row._3)
+        }
       )
 
       val assertion = for {

--- a/mysql/src/test/scala/zio/sql/mysql/MysqlModuleTest.scala
+++ b/mysql/src/test/scala/zio/sql/mysql/MysqlModuleTest.scala
@@ -55,10 +55,9 @@ object MysqlModuleTest extends MysqlRunnableSpec with ShopSchema {
           )
         )
 
-      val testResult = execute(
-        query).map { case row =>
-          Customer(row._1, row._2, row._3, row._4)
-        }
+      val testResult = execute(query).map { case row =>
+        Customer(row._1, row._2, row._3, row._4)
+      }
 
       val assertion = for {
         r <- testResult.runCollect
@@ -84,10 +83,9 @@ object MysqlModuleTest extends MysqlRunnableSpec with ShopSchema {
           )
         )
 
-      val testResult = execute(
-        query).map { case row =>
-          Customer(row._1, row._2, row._3, row._4, row._5)
-        }
+      val testResult = execute(query).map { case row =>
+        Customer(row._1, row._2, row._3, row._4, row._5)
+      }
 
       val assertion = for {
         r <- testResult.runCollect
@@ -113,8 +111,8 @@ object MysqlModuleTest extends MysqlRunnableSpec with ShopSchema {
         )
 
       val testResult = execute(query).map { case row =>
-          Customer(row._1, row._2, row._3, row._4)
-        }
+        Customer(row._1, row._2, row._3, row._4)
+      }
 
       val assertion = for {
         r <- testResult.runCollect
@@ -154,8 +152,8 @@ object MysqlModuleTest extends MysqlRunnableSpec with ShopSchema {
       )
 
       val result = execute(query).map { case row =>
-          Row(row._1, row._2, row._3)
-        }
+        Row(row._1, row._2, row._3)
+      }
 
       val assertion = for {
         r <- result.runCollect

--- a/mysql/src/test/scala/zio/sql/mysql/ShopSchema.scala
+++ b/mysql/src/test/scala/zio/sql/mysql/ShopSchema.scala
@@ -10,24 +10,24 @@ trait ShopSchema extends Jdbc { self =>
       (uuid("id") ++ localDate("dob") ++ string("first_name") ++ string("last_name") ++ boolean("verified"))
         .table("customers")
 
-    val customerId :*: dob :*: fName :*: lName :*: verified :*: _ = customers.columns
+    val (customerId, dob, fName, lName, verified) = customers.columns
   }
   object Orders        {
     val orders = (uuid("id") ++ uuid("customer_id") ++ localDate("order_date")).table("orders")
 
-    val orderId :*: fkCustomerId :*: orderDate :*: _ = orders.columns
+    val (orderId, fkCustomerId, orderDate) = orders.columns
   }
   object Products      {
     val products =
       (int("id") ++ string("name") ++ string("description") ++ string("image_url")).table("products")
 
-    val productId :*: description :*: imageURL :*: _ = products.columns
+    val (productId, producttName, description, imageURL) = products.columns
   }
   object ProductPrices {
     val productPrices =
       (int("product_id") ++ offsetDateTime("effective") ++ bigDecimal("price")).table("product_prices")
 
-    val fkProductId :*: effective :*: price :*: _ = productPrices.columns
+    val (fkProductId, effective, price) = productPrices.columns
   }
 
   object OrderDetails {
@@ -37,6 +37,6 @@ trait ShopSchema extends Jdbc { self =>
           "order_details"
         ) //todo fix #3 quantity should be int, unit price should be bigDecimal, numeric operators only support double ATM.
 
-    val fkOrderId :*: fkProductId :*: quantity :*: unitPrice :*: _ = orderDetails.columns
+    val (fkOrderId, fkProductId, quantity, unitPrice) = orderDetails.columns
   }
 }

--- a/oracle/src/main/scala/zio/sql/oracle/OracleModule.scala
+++ b/oracle/src/main/scala/zio/sql/oracle/OracleModule.scala
@@ -133,7 +133,7 @@ trait OracleModule extends Jdbc { self =>
     read match {
       case Read.Mapped(read, _) => buildReadString(read, builder)
 
-      case read0 @ Read.Subselect(_, _, _, _, _, _, _, _, _) =>
+      case read0 @ Read.Subselect(_, _, _, _, _, _, _, _) =>
         object Dummy {
           type F
           type Repr
@@ -157,7 +157,7 @@ trait OracleModule extends Jdbc { self =>
             buildExpr(whereExpr, builder)
         }
         groupByExprs match {
-          case _ :: _ =>
+          case Read.ExprSet.ExprCons(_, _) =>
             builder.append(" GROUP BY ")
             buildExprList(groupByExprs, builder)
 
@@ -167,7 +167,7 @@ trait OracleModule extends Jdbc { self =>
                 builder.append(" HAVING ")
                 buildExpr(havingExpr, builder)
             }
-          case Nil    => ()
+          case Read.ExprSet.NoExpr    => ()
         }
         orderByExprs match {
           case _ :: _ =>
@@ -199,17 +199,17 @@ trait OracleModule extends Jdbc { self =>
         val _ = builder.append(" (").append(values.mkString(",")).append(") ") //todo fix needs escaping
     }
 
-  def buildExprList(expr: List[Expr[_, _, _]], builder: StringBuilder): Unit               =
+  def buildExprList(expr: Read.ExprSet[_], builder: StringBuilder): Unit               =
     expr match {
-      case head :: tail =>
+      case Read.ExprSet.ExprCons(head, tail) => 
         buildExpr(head, builder)
         tail match {
-          case _ :: _ =>
+          case Read.ExprSet.ExprCons(_, _) =>
             builder.append(", ")
             buildExprList(tail, builder)
-          case Nil    => ()
+          case Read.ExprSet.NoExpr    => ()
         }
-      case Nil          => ()
+      case Read.ExprSet.NoExpr => ()
     }
   def buildOrderingList(expr: List[Ordering[Expr[_, _, _]]], builder: StringBuilder): Unit =
     expr match {

--- a/oracle/src/main/scala/zio/sql/oracle/OracleModule.scala
+++ b/oracle/src/main/scala/zio/sql/oracle/OracleModule.scala
@@ -133,7 +133,7 @@ trait OracleModule extends Jdbc { self =>
     read match {
       case Read.Mapped(read, _) => buildReadString(read, builder)
 
-      case read0 @ Read.Subselect(_, _, _, _, _, _, _, _) =>
+      case read0 @ Read.Subselect(_, _, _, _, _, _, _, _, _) =>
         object Dummy {
           type F
           type Repr
@@ -156,10 +156,10 @@ trait OracleModule extends Jdbc { self =>
             builder.append(" WHERE ")
             buildExpr(whereExpr, builder)
         }
-        groupBy match {
+        groupByExprs match {
           case _ :: _ =>
             builder.append(" GROUP BY ")
-            buildExprList(groupBy, builder)
+            buildExprList(groupByExprs, builder)
 
             havingExpr match {
               case Expr.Literal(true) => ()
@@ -169,10 +169,10 @@ trait OracleModule extends Jdbc { self =>
             }
           case Nil    => ()
         }
-        orderBy match {
+        orderByExprs match {
           case _ :: _ =>
             builder.append(" ORDER BY ")
-            buildOrderingList(orderBy, builder)
+            buildOrderingList(orderByExprs, builder)
           case Nil    => ()
         }
         // NOTE: Limit doesn't exist in oracle 11g (>=12), for now replacing it with rownum keyword of oracle

--- a/oracle/src/main/scala/zio/sql/oracle/OracleModule.scala
+++ b/oracle/src/main/scala/zio/sql/oracle/OracleModule.scala
@@ -131,8 +131,6 @@ trait OracleModule extends Jdbc { self =>
 
   def buildReadString(read: self.Read[_], builder: StringBuilder): Unit =
     read match {
-      case Read.Mapped(read, _) => buildReadString(read, builder)
-
       case read0 @ Read.Subselect(_, _, _, _, _, _, _, _) =>
         object Dummy {
           type F

--- a/oracle/src/main/scala/zio/sql/oracle/OracleModule.scala
+++ b/oracle/src/main/scala/zio/sql/oracle/OracleModule.scala
@@ -132,7 +132,7 @@ trait OracleModule extends Jdbc { self =>
   def buildReadString(read: self.Read[_], builder: StringBuilder): Unit =
     read match {
       case Read.Mapped(read, _) => buildReadString(read, builder)
-      
+
       case read0 @ Read.Subselect(_, _, _, _, _, _, _, _) =>
         object Dummy {
           type F

--- a/oracle/src/main/scala/zio/sql/oracle/OracleModule.scala
+++ b/oracle/src/main/scala/zio/sql/oracle/OracleModule.scala
@@ -131,6 +131,8 @@ trait OracleModule extends Jdbc { self =>
 
   def buildReadString(read: self.Read[_], builder: StringBuilder): Unit =
     read match {
+      case Read.Mapped(read, _) => buildReadString(read, builder)
+      
       case read0 @ Read.Subselect(_, _, _, _, _, _, _, _) =>
         object Dummy {
           type F

--- a/oracle/src/main/scala/zio/sql/oracle/OracleModule.scala
+++ b/oracle/src/main/scala/zio/sql/oracle/OracleModule.scala
@@ -167,7 +167,7 @@ trait OracleModule extends Jdbc { self =>
                 builder.append(" HAVING ")
                 buildExpr(havingExpr, builder)
             }
-          case Read.ExprSet.NoExpr    => ()
+          case Read.ExprSet.NoExpr         => ()
         }
         orderByExprs match {
           case _ :: _ =>
@@ -199,17 +199,17 @@ trait OracleModule extends Jdbc { self =>
         val _ = builder.append(" (").append(values.mkString(",")).append(") ") //todo fix needs escaping
     }
 
-  def buildExprList(expr: Read.ExprSet[_], builder: StringBuilder): Unit               =
+  def buildExprList(expr: Read.ExprSet[_], builder: StringBuilder): Unit                   =
     expr match {
-      case Read.ExprSet.ExprCons(head, tail) => 
+      case Read.ExprSet.ExprCons(head, tail) =>
         buildExpr(head, builder)
-        tail match {
+        tail.asInstanceOf[Read.ExprSet[_]] match {
           case Read.ExprSet.ExprCons(_, _) =>
             builder.append(", ")
-            buildExprList(tail, builder)
-          case Read.ExprSet.NoExpr    => ()
+            buildExprList(tail.asInstanceOf[Read.ExprSet[_]], builder)
+          case Read.ExprSet.NoExpr         => ()
         }
-      case Read.ExprSet.NoExpr => ()
+      case Read.ExprSet.NoExpr               => ()
     }
   def buildOrderingList(expr: List[Ordering[Expr[_, _, _]]], builder: StringBuilder): Unit =
     expr match {

--- a/postgres/src/main/scala/zio/sql/postgresql/PostgresModule.scala
+++ b/postgres/src/main/scala/zio/sql/postgresql/PostgresModule.scala
@@ -84,9 +84,9 @@ trait PostgresModule extends Jdbc { self =>
     trait PostgresTypeTag[+A] extends Tag[A] with Decodable[A]
     object PostgresTypeTag {
       implicit case object TVoid       extends PostgresTypeTag[Unit]       {
-        override def decode(column: Either[Int, String], resultSet: ResultSet): Either[DecodingError, Unit] =
+        override def decode(column: Int, resultSet: ResultSet): Either[DecodingError, Unit] =
           scala.util
-            .Try(column.fold(resultSet.getObject(_), resultSet.getObject(_)))
+            .Try(resultSet.getObject(column))
             .fold(
               _ => Left(DecodingError.UnexpectedNull(column)),
               _ => Right(())
@@ -94,11 +94,11 @@ trait PostgresModule extends Jdbc { self =>
       }
       implicit case object TInterval   extends PostgresTypeTag[Interval]   {
         override def decode(
-          column: Either[Int, String],
+          column: Int,
           resultSet: ResultSet
         ): Either[DecodingError, Interval] =
           scala.util
-            .Try(Interval.fromPgInterval(new PGInterval(column.fold(resultSet.getString(_), resultSet.getString(_)))))
+            .Try(Interval.fromPgInterval(new PGInterval(resultSet.getString(column))))
             .fold(
               _ => Left(DecodingError.UnexpectedNull(column)),
               r => Right(r)
@@ -106,7 +106,7 @@ trait PostgresModule extends Jdbc { self =>
       }
       implicit case object TTimestampz extends PostgresTypeTag[Timestampz] {
         override def decode(
-          column: Either[Int, String],
+          column: Int,
           resultSet: ResultSet
         ): Either[DecodingError, Timestampz] =
           scala.util
@@ -114,7 +114,7 @@ trait PostgresModule extends Jdbc { self =>
               Timestampz.fromZonedDateTime(
                 ZonedDateTime
                   .ofInstant(
-                    column.fold(resultSet.getTimestamp(_), resultSet.getTimestamp(_)).toInstant,
+                    resultSet.getTimestamp(column).toInstant,
                     ZoneId.of(ZoneOffset.UTC.getId)
                   )
               )
@@ -445,12 +445,14 @@ trait PostgresModule extends Jdbc { self =>
               }
             case None    => ()
           }
-        //TODO what about other cases?
         case DynamicValue.Transform(that)           => renderDynamicValue(that)
         case DynamicValue.Tuple(left, right)        =>
           renderDynamicValue(left)
           render(", ")
           renderDynamicValue(right)
+        case DynamicValue.SomeValue(value)          => renderDynamicValue(value)
+        case DynamicValue.NoneValue                 => render(s"null")
+        //TODO what about other cases?
         case _                                      => ()
       }
 

--- a/postgres/src/main/scala/zio/sql/postgresql/PostgresModule.scala
+++ b/postgres/src/main/scala/zio/sql/postgresql/PostgresModule.scala
@@ -671,7 +671,6 @@ trait PostgresModule extends Jdbc { self =>
 
     private[zio] def renderReadImpl(read: self.Read[_])(implicit render: Renderer): Unit =
       read match {
-        case Read.Mapped(read, _)                           => renderReadImpl(read)
         case read0 @ Read.Subselect(_, _, _, _, _, _, _, _) =>
           object Dummy {
             type F

--- a/postgres/src/main/scala/zio/sql/postgresql/PostgresModule.scala
+++ b/postgres/src/main/scala/zio/sql/postgresql/PostgresModule.scala
@@ -671,6 +671,8 @@ trait PostgresModule extends Jdbc { self =>
 
     private[zio] def renderReadImpl(read: self.Read[_])(implicit render: Renderer): Unit =
       read match {
+        case Read.Mapped(read, _) => renderReadImpl(read)
+        
         case read0 @ Read.Subselect(_, _, _, _, _, _, _, _) =>
           object Dummy {
             type F

--- a/postgres/src/main/scala/zio/sql/postgresql/PostgresModule.scala
+++ b/postgres/src/main/scala/zio/sql/postgresql/PostgresModule.scala
@@ -406,7 +406,6 @@ trait PostgresModule extends Jdbc { self =>
             case Some(v) =>
               v match {
                 case BigDecimalType                             =>
-                  println("foo")
                   render(value)
                 case StandardType.InstantType(formatter)        =>
                   render(s"'${formatter.format(value.asInstanceOf[Instant])}'")
@@ -671,7 +670,7 @@ trait PostgresModule extends Jdbc { self =>
     private[zio] def renderReadImpl(read: self.Read[_])(implicit render: Renderer): Unit =
       read match {
         case Read.Mapped(read, _)                           => renderReadImpl(read)
-        case read0 @ Read.Subselect(_, _, _, _, _, _, _, _) =>
+        case read0 @ Read.Subselect(_, _, _, _, _, _, _, _, _) =>
           object Dummy {
             type F
             type Repr
@@ -695,10 +694,10 @@ trait PostgresModule extends Jdbc { self =>
               render(" WHERE ")
               renderExpr(whereExpr)
           }
-          groupBy match {
+          groupByExprs match {
             case _ :: _ =>
               render(" GROUP BY ")
-              renderExprList(groupBy)
+              renderExprList(groupByExprs)
 
               havingExpr match {
                 case Expr.Literal(true) => ()
@@ -708,10 +707,10 @@ trait PostgresModule extends Jdbc { self =>
               }
             case Nil    => ()
           }
-          orderBy match {
+          orderByExprs match {
             case _ :: _ =>
               render(" ORDER BY ")
-              renderOrderingList(orderBy)
+              renderOrderingList(orderByExprs)
             case Nil    => ()
           }
           limit match {

--- a/postgres/src/main/scala/zio/sql/postgresql/PostgresModule.scala
+++ b/postgres/src/main/scala/zio/sql/postgresql/PostgresModule.scala
@@ -672,7 +672,7 @@ trait PostgresModule extends Jdbc { self =>
     private[zio] def renderReadImpl(read: self.Read[_])(implicit render: Renderer): Unit =
       read match {
         case Read.Mapped(read, _) => renderReadImpl(read)
-        
+
         case read0 @ Read.Subselect(_, _, _, _, _, _, _, _) =>
           object Dummy {
             type F

--- a/postgres/src/main/scala/zio/sql/postgresql/PostgresModule.scala
+++ b/postgres/src/main/scala/zio/sql/postgresql/PostgresModule.scala
@@ -705,7 +705,7 @@ trait PostgresModule extends Jdbc { self =>
                   render(" HAVING ")
                   renderExpr(havingExpr)
               }
-            case Read.ExprSet.NoExpr    => ()
+            case Read.ExprSet.NoExpr         => ()
           }
           orderByExprs match {
             case _ :: _ =>
@@ -734,15 +734,15 @@ trait PostgresModule extends Jdbc { self =>
 
     def renderExprList(expr: Read.ExprSet[_])(implicit render: Renderer): Unit =
       expr match {
-        case Read.ExprSet.ExprCons(head, tail) => 
+        case Read.ExprSet.ExprCons(head, tail) =>
           renderExpr(head)
-          tail match {
+          tail.asInstanceOf[Read.ExprSet[_]] match {
             case Read.ExprSet.ExprCons(_, _) =>
               render(", ")
-              renderExprList(tail)
-            case Read.ExprSet.NoExpr    => ()
+              renderExprList(tail.asInstanceOf[Read.ExprSet[_]])
+            case Read.ExprSet.NoExpr         => ()
           }
-        case Read.ExprSet.NoExpr => ()
+        case Read.ExprSet.NoExpr               => ()
       }
 
     def renderOrderingList(expr: List[Ordering[Expr[_, _, _]]])(implicit render: Renderer): Unit =

--- a/postgres/src/test/resources/shop_schema.sql
+++ b/postgres/src/test/resources/shop_schema.sql
@@ -39,6 +39,14 @@ create table order_details
     unit_price money not null
 );
 
+create table persons
+(
+    id uuid not null primary key,
+    first_name varchar not null,
+    last_name varchar,
+    dob date
+);
+
 insert into customers
     (id, first_name, last_name, verified, dob, created_timestamp_string, created_timestamp)
 values
@@ -47,6 +55,15 @@ values
     ('784426a5-b90a-4759-afbb-571b7a0ba35e', 'Mila', 'Paterso', true, '1990-11-16', '2020-11-22T02:10:25+07:00', '2020-11-22 02:10:25+07'),
     ('df8215a2-d5fd-4c6c-9984-801a1b3a2a0b', 'Alana', 'Murray', true, '1995-11-12', '2020-11-21T12:10:25-07:00', '2020-11-21 12:10:25-07'),
     ('636ae137-5b1a-4c8c-b11f-c47c624d9cdc', 'Jose', 'Wiggins', false, '1987-03-23', '2020-11-21T19:10:25+00:00', '2020-11-21 19:10:25+00');
+
+insert into persons
+    (id, first_name, last_name, dob)
+values
+    ('60b01fc9-c902-4468-8d49-3c0f989def37', 'Ronald', 'Russell', '1983-01-05'),
+    ('f76c9ace-be07-4bf3-bd4c-4a9c62882e64', 'Terrence', 'Noel', null),
+    ('784426a5-b90a-4759-afbb-571b7a0ba35e', 'Mila', 'Paterso', '1990-11-16'),
+    ('df8215a2-d5fd-4c6c-9984-801a1b3a2a0b', 'Alana', 'Murray', '1995-11-12'),
+    ('636ae137-5b1a-4c8c-b11f-c47c624d9cdc', 'Jose', null,  null);
 
 insert into products
     (id, name, description, image_url)

--- a/postgres/src/test/scala/zio/sql/postgresql/FunctionDefSpec.scala
+++ b/postgres/src/test/scala/zio/sql/postgresql/FunctionDefSpec.scala
@@ -46,7 +46,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
         "1+2+3"
       )
 
-      val testResult = execute(query.to(identity))
+      val testResult = execute(query)
       collectAndCompare(expected, testResult)
     },
     testM("concat_ws #2 - combine columns") {
@@ -63,7 +63,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
         "JoseJoseWiggins"
       )
 
-      val testResult = execute(query.to(identity))
+      val testResult = execute(query)
       collectAndCompare(expected, testResult)
     },
     testM("concat_ws #3 - combine columns and flat values") {
@@ -79,7 +79,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
         "Person: Jose Wiggins"
       )
 
-      val testResult = execute(query.to(identity))
+      val testResult = execute(query)
       collectAndCompare(expected, testResult)
     },
     testM("concat_ws #3 - combine function calls together") {
@@ -97,7 +97,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
         "Name: Jose and Surname: Wiggins"
       )
 
-      val testResult = execute(query.to(identity))
+      val testResult = execute(query)
       collectAndCompare(expected, testResult)
     },
     testM("isfinite") {
@@ -105,7 +105,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
 
       val expected: Boolean = true
 
-      val testResult = execute(query.to(identity))
+      val testResult = execute(query)
 
       val assertion = for {
         r <- testResult.runCollect
@@ -118,7 +118,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
         val query    = select(Length("hello"))
         val expected = 5
 
-        val testResult = execute(query.to(identity))
+        val testResult = execute(query)
 
         val assertion = for {
           r <- testResult.runCollect
@@ -131,7 +131,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
 
         val expected = "hello  "
 
-        val testResult = execute(query.to(identity))
+        val testResult = execute(query)
 
         val assertion = for {
           r <- testResult.runCollect
@@ -144,7 +144,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
 
         val expected = "  hello"
 
-        val testResult = execute(query.to(identity))
+        val testResult = execute(query)
 
         val assertion = for {
           r <- testResult.runCollect
@@ -157,7 +157,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
 
         val expected = 40
 
-        val testResult = execute(query.to(identity))
+        val testResult = execute(query)
 
         val assertion = for {
           r <- testResult.runCollect
@@ -170,7 +170,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
 
         val expected = 3.141592653589793
 
-        val testResult = execute(query.to(identity))
+        val testResult = execute(query)
 
         val assertion = for {
           r <- testResult.runCollect
@@ -192,7 +192,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
             "Person"
           )
 
-          val testResult = execute(query.to(identity))
+          val testResult = execute(query)
           collectAndCompare(expected, testResult)
         },
         testM("format1") {
@@ -208,7 +208,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
             "Person: Jose"
           )
 
-          val testResult = execute(query.to(identity))
+          val testResult = execute(query)
           collectAndCompare(expected, testResult)
         },
         testM("format2") {
@@ -224,7 +224,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
             "Person: Jose Wiggins"
           )
 
-          val testResult = execute(query.to(identity))
+          val testResult = execute(query)
           collectAndCompare(expected, testResult)
         },
         testM("format3") {
@@ -242,7 +242,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
             s"""Person: Jose Wiggins with double quoted "identi fier" """
           )
 
-          val testResult = execute(query.to(identity))
+          val testResult = execute(query)
           collectAndCompare(expected, testResult)
         },
         testM("format4") {
@@ -266,7 +266,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
             s"""Person: Jose Wiggins with null-literal 'FIXME: NULL' and non-null-literal 'literal' """
           )
 
-          val testResult = execute(query.to(identity))
+          val testResult = execute(query)
           collectAndCompare(expected, testResult)
         },
         testM("format5") {
@@ -291,7 +291,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
             s"""Person: Jose Wiggins with more arguments than placeholders: identifier 'esoJ' """
           )
 
-          val testResult = execute(query.to(identity))
+          val testResult = execute(query)
           collectAndCompare(expected, testResult)
         }
       )
@@ -301,7 +301,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
 
       val expected = 3.14159
 
-      val testResult = execute(query.to(identity))
+      val testResult = execute(query)
 
       val assertion = for {
         r <- testResult.runCollect
@@ -314,7 +314,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
 
       val expected: Double = 5
 
-      val testResult = execute(query.to(identity))
+      val testResult = execute(query)
 
       val assertion = for {
         r <- testResult.runCollect
@@ -327,7 +327,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
 
       val expected = 3.141592653589793
 
-      val testResult = execute(query.to(identity))
+      val testResult = execute(query)
 
       val assertion = for {
         r <- testResult.runCollect
@@ -340,7 +340,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
 
       val expected = "ZioZioZio"
 
-      val testResult = execute(query.to(identity))
+      val testResult = execute(query)
 
       val assertion = for {
         r <- testResult.runCollect
@@ -353,7 +353,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
 
       val expected = 0.5235987755982989
 
-      val testResult = execute(query.to(identity))
+      val testResult = execute(query)
 
       val assertion = for {
         r <- testResult.runCollect
@@ -366,7 +366,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
 
       val expected = 1.0986122886681097
 
-      val testResult = execute(query.to(identity))
+      val testResult = execute(query)
 
       val assertion = for {
         r <- testResult.runCollect
@@ -379,7 +379,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
 
       val expected = 1.4711276743037347
 
-      val testResult = execute(query.to(identity))
+      val testResult = execute(query)
 
       val assertion = for {
         r <- testResult.runCollect
@@ -392,7 +392,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
 
       val expected = "dcba"
 
-      val testResult = execute(query.to(identity))
+      val testResult = execute(query)
 
       val assertion = for {
         r <- testResult.runCollect
@@ -405,7 +405,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
 
       val expected = -1.0
 
-      val testResult = execute(query.to(identity))
+      val testResult = execute(query)
 
       val assertion = for {
         r <- testResult.runCollect
@@ -418,7 +418,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
 
       val expected = 2.718281828459045
 
-      val testResult = execute(query.to(identity))
+      val testResult = execute(query)
 
       val assertion = for {
         r <- testResult.runCollect
@@ -431,7 +431,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
 
       val expected = -4.0
 
-      val testResult = execute(query.to(identity))
+      val testResult = execute(query)
 
       val assertion = for {
         r <- testResult.runCollect
@@ -444,7 +444,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
 
       val expected = (54.0, -53.0)
 
-      val testResult = execute(query.to(value => (value._1, value._2)))
+      val testResult = execute(query).map(value => (value._1, value._2))
 
       val assertion = for {
         r <- testResult.runCollect
@@ -457,7 +457,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
 
       val expected = 0.8414709848078965
 
-      val testResult = execute(query.to(identity))
+      val testResult = execute(query)
 
       val assertion = for {
         r <- testResult.runCollect
@@ -470,7 +470,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
 
       val expected = 0.5
 
-      val testResult = execute(query.to(identity))
+      val testResult = execute(query)
 
       val assertion = for {
         r <- testResult.runCollect
@@ -483,7 +483,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
 
       val expected = "def"
 
-      val testResult = execute(query.to(identity))
+      val testResult = execute(query)
 
       val assertion = for {
         r <- testResult.runCollect
@@ -494,7 +494,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
     testM("timeofday") {
       val query = select(TimeOfDay())
 
-      val testResult = execute(query.to(identity))
+      val testResult = execute(query)
 
       val assertion =
         for {
@@ -509,7 +509,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
     testM("localtime") {
       val query = select(Localtime)
 
-      val testResult = execute(query.to(identity))
+      val testResult = execute(query)
 
       val assertion = for {
         r <- testResult.runCollect
@@ -521,7 +521,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
       val precision = 0
       val query     = select(LocaltimeWithPrecision(precision))
 
-      val testResult = execute(query.to(identity))
+      val testResult = execute(query)
 
       val assertion = for {
         r <- testResult.runCollect
@@ -532,7 +532,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
     testM("localtimestamp") {
       val query = select(Localtimestamp)
 
-      val testResult = execute(query.to(identity))
+      val testResult = execute(query)
 
       val assertion =
         for {
@@ -548,7 +548,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
 
       val query = select(LocaltimestampWithPrecision(precision))
 
-      val testResult = execute(query.to(identity))
+      val testResult = execute(query)
 
       val assertion =
         for {
@@ -562,7 +562,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
     testM("now") {
       val query = select(Now())
 
-      val testResult = execute(query.to(identity))
+      val testResult = execute(query)
 
       val assertion =
         for {
@@ -576,7 +576,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
     testM("statement_timestamp") {
       val query = select(StatementTimestamp())
 
-      val testResult = execute(query.to(identity))
+      val testResult = execute(query)
 
       val assertion =
         for {
@@ -590,7 +590,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
     testM("transaction_timestamp") {
       val query = select(TransactionTimestamp())
 
-      val testResult = execute(query.to(identity))
+      val testResult = execute(query)
 
       val assertion =
         for {
@@ -604,7 +604,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
     testM("current_time") {
       val query = select(CurrentTime)
 
-      val testResult = execute(query.to(identity))
+      val testResult = execute(query)
 
       val assertion =
         for {
@@ -622,7 +622,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
 
       val expected = "3adbbad1791fbae3ec908894c4963870"
 
-      val testResult = execute(query.to(identity))
+      val testResult = execute(query)
 
       val assertion = for {
         r <- testResult.runCollect
@@ -643,7 +643,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
 
         val assertion = checkM(genTestString) { (testString) =>
           val query      = select(ParseIdent(testString))
-          val testResult = execute(query.to(identity))
+          val testResult = execute(query)
 
           for {
             r <- testResult.runCollect
@@ -654,7 +654,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
       },
       testM("parseIdent fails with invalid identifier") {
         val query      = select(ParseIdent("\'\"SomeSchema\".someTable.\'"))
-        val testResult = execute(query.to(identity))
+        val testResult = execute(query)
 
         val assertion = for {
           r <- testResult.runCollect.run
@@ -668,7 +668,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
 
       val expected = 11.0
 
-      val testResult = execute(query.to(identity))
+      val testResult = execute(query)
 
       val assertion = for {
         r <- testResult.runCollect
@@ -681,7 +681,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
 
       val expected = "A"
 
-      val testResult = execute(query.to(identity))
+      val testResult = execute(query)
 
       val assertion = for {
         r <- testResult.runCollect
@@ -694,7 +694,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
 
       val expected = LocalDate.now()
 
-      val testResult = execute(query.to(identity))
+      val testResult = execute(query)
 
       val assertion = for {
         r <- testResult.runCollect
@@ -707,7 +707,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
 
       val expected = "Hi Thomas"
 
-      val testResult = execute(query.to(identity))
+      val testResult = execute(query)
 
       val assertion = for {
         r <- testResult.runCollect
@@ -720,7 +720,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
 
       val expected = 8.41
 
-      val testResult = execute(query.to(identity))
+      val testResult = execute(query)
 
       val assertion = for {
         r <- testResult.runCollect
@@ -733,7 +733,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
 
       val expected = "7fffffff"
 
-      val testResult = execute(query.to(identity))
+      val testResult = execute(query)
 
       val assertion = for {
         r <- testResult.runCollect
@@ -746,7 +746,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
 
       val expected = "SGVsbG8sIFdvcmxkIQ=="
 
-      val testResult = execute(query.to(identity))
+      val testResult = execute(query)
 
       val assertion = for {
         r <- testResult.runCollect
@@ -759,7 +759,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
 
       val expected = Chunk.fromArray("Hello, World!".getBytes)
 
-      val testResult = execute(query.to(identity))
+      val testResult = execute(query)
 
       val assertion = for {
         r <- testResult.runCollect
@@ -772,7 +772,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
 
       val expected = 42d
 
-      val testResult = execute(query.to(identity))
+      val testResult = execute(query)
 
       val assertion = for {
         r <- testResult.runCollect
@@ -785,7 +785,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
 
       val expected = 10.81
 
-      val testResult = execute(query.to(identity))
+      val testResult = execute(query)
 
       val assertion = for {
         r <- testResult.runCollect
@@ -798,7 +798,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
 
       val expected = 1
 
-      val testResult = execute(query.to(identity))
+      val testResult = execute(query)
 
       val assertion = for {
         r <- testResult.runCollect
@@ -811,7 +811,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
 
       val expected = -1
 
-      val testResult = execute(query.to(identity))
+      val testResult = execute(query)
 
       val assertion = for {
         r <- testResult.runCollect
@@ -824,7 +824,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
 
       val expected = 0
 
-      val testResult = execute(query.to(identity))
+      val testResult = execute(query)
 
       val assertion = for {
         r <- testResult.runCollect
@@ -837,7 +837,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
 
       val expected = 343.000000000000000
 
-      val testResult = execute(query.to(identity))
+      val testResult = execute(query)
 
       val assertion = for {
         r <- testResult.runCollect
@@ -850,7 +850,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
 
       val expected = 5
 
-      val testResult = execute(query.to(identity))
+      val testResult = execute(query)
 
       val assertion = for {
         r <- testResult.runCollect
@@ -863,7 +863,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
 
       val expected = -3.0
 
-      val testResult = execute(query.to(identity))
+      val testResult = execute(query)
 
       val assertion = for {
         r <- testResult.runCollect
@@ -876,7 +876,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
 
       val expected = "a2x5"
 
-      val testResult = execute(query.to(identity))
+      val testResult = execute(query)
 
       val assertion = for {
         r <- testResult.runCollect
@@ -889,7 +889,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
 
       val expected = "ab"
 
-      val testResult = execute(query.to(identity))
+      val testResult = execute(query)
 
       val assertion = for {
         r <- testResult.runCollect
@@ -902,7 +902,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
 
       val expected = "de"
 
-      val testResult = execute(query.to(identity))
+      val testResult = execute(query)
 
       val assertion = for {
         r <- testResult.runCollect
@@ -915,7 +915,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
 
       val expected = 0.7853981634
 
-      val testResult = execute(query.to(identity))
+      val testResult = execute(query)
 
       val assertion = for {
         r <- testResult.runCollect
@@ -928,7 +928,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
 
       val expected = 2
 
-      val testResult = execute(query.to(identity))
+      val testResult = execute(query)
 
       val assertion = for {
         r <- testResult.runCollect
@@ -953,11 +953,9 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
           )
         )
 
-      val testResult = execute(
-        query.to { case (id, fname, lname, verified, dob) =>
+      val testResult = execute(query).map { case (id, fname, lname, verified, dob) =>
           Customer(id, fname, lname, verified, dob)
         }
-      )
 
       val assertion = for {
         r <- testResult.runCollect
@@ -970,7 +968,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
 
       val expected = "ronald"
 
-      val testResult = execute(query.to(identity))
+      val testResult = execute(query)
 
       val assertion = for {
         r <- testResult.runCollect
@@ -983,7 +981,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
 
       val expected = "lower"
 
-      val testResult = execute(query.to(identity))
+      val testResult = execute(query)
 
       val assertion = for {
         r <- testResult.runCollect
@@ -996,7 +994,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
 
       val expected = 5
 
-      val testResult = execute(query.to(identity))
+      val testResult = execute(query)
 
       val assertion = for {
         r <- testResult.runCollect
@@ -1009,7 +1007,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
 
       val expected = 120
 
-      val testResult = execute(query.to(identity))
+      val testResult = execute(query)
 
       val assertion = for {
         r <- testResult.runCollect
@@ -1022,7 +1020,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
 
       val expected = "RONALD"
 
-      val testResult = execute(query.to(identity))
+      val testResult = execute(query)
 
       val assertion = for {
         r <- testResult.runCollect
@@ -1035,7 +1033,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
 
       val expected = 3
 
-      val testResult = execute(query.to(identity))
+      val testResult = execute(query)
 
       val assertion = for {
         r <- testResult.runCollect
@@ -1048,7 +1046,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
 
       val expected = 1.0000000000051035
 
-      val testResult = execute(query.to(identity))
+      val testResult = execute(query)
 
       val assertion = for {
         r <- testResult.runCollect
@@ -1061,7 +1059,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
 
       val expected = 21d
 
-      val testResult = execute(query.to(identity))
+      val testResult = execute(query)
 
       val assertion = for {
         r <- testResult.runCollect
@@ -1074,7 +1072,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
 
       val expected = 23562d
 
-      val testResult = execute(query.to(identity))
+      val testResult = execute(query)
 
       val assertion = for {
         r <- testResult.runCollect
@@ -1087,7 +1085,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
 
       val expected = 4d
 
-      val testResult = execute(query.to(identity))
+      val testResult = execute(query)
 
       val assertion = for {
         r <- testResult.runCollect
@@ -1100,7 +1098,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
 
       val expected = 28.64788975654116
 
-      val testResult = execute(query.to(identity))
+      val testResult = execute(query)
 
       val assertion = for {
         r <- testResult.runCollect
@@ -1113,7 +1111,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
 
       val expected = 2d
 
-      val testResult = execute(query.to(identity))
+      val testResult = execute(query)
 
       val assertion = for {
         r <- testResult.runCollect
@@ -1126,7 +1124,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
 
       val expected = 120
 
-      val testResult = execute(query.to(identity))
+      val testResult = execute(query)
 
       val assertion = for {
         r <- testResult.runCollect
@@ -1137,7 +1135,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
     testM("random") {
       val query = select(Random())
 
-      val testResult = execute(query.to(identity))
+      val testResult = execute(query)
 
       val assertion = for {
         r <- testResult.runCollect
@@ -1149,7 +1147,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
       val query = select(SetSeed(0.12) ++ Random() ++ Random()) from customers
 
       val randomTupleForSeed = (0.019967750719779076, 0.8378369929936333)
-      val testResult         = execute(query.to { case (_, b, c) => (b, c) })
+      val testResult         = execute(query).map { case (_, b, c) => (b, c) }
 
       val assertion = for {
         r <- testResult.runCollect
@@ -1163,7 +1161,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
 
       val expected = Seq("RonaldRussell", "TerrenceNoel", "MilaPaterso", "AlanaMurray", "JoseWiggins")
 
-      val result = execute(query.to(identity))
+      val result = execute(query)
 
       val assertion = for {
         r <- result.runCollect
@@ -1177,7 +1175,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
 
       val expected = Seq(6, 8, 4, 5, 4)
 
-      val result = execute(query.to(identity))
+      val result = execute(query)
 
       val assertion = for {
         r <- result.runCollect
@@ -1188,14 +1186,14 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
     testM("to_timestamp") {
       val query      = select(ToTimestamp(1284352323L))
       val expected   = ZonedDateTime.of(2010, 9, 13, 4, 32, 3, 0, ZoneId.of(ZoneOffset.UTC.getId))
-      val testResult = execute(query.to(identity))
+      val testResult = execute(query)
 
       val expectedRoundTripTimestamp = ZonedDateTime.of(2020, 11, 21, 19, 10, 25, 0, ZoneId.of(ZoneOffset.UTC.getId))
       val roundTripQuery             =
         select(createdString ++ createdTimestamp) from customers
-      val roundTripResults           = execute(roundTripQuery.to { case row =>
+      val roundTripResults           = execute(roundTripQuery).map { case row =>
         (row._1, ZonedDateTime.parse(row._1), row._2)
-      })
+      }
       val roundTripExpected          = List(
         ("2020-11-21T19:10:25+00:00", ZonedDateTime.parse("2020-11-21T19:10:25+00:00"), expectedRoundTripTimestamp),
         ("2020-11-21T15:10:25-04:00", ZonedDateTime.parse("2020-11-21T15:10:25-04:00"), expectedRoundTripTimestamp),
@@ -1220,9 +1218,9 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
       val expected = ("Russe_", "special ::__::")
 
       val testResult =
-        execute(query.to { case row =>
+        execute(query).map { case row =>
           (row._1, row._2)
-        })
+        }
 
       val assertion = for {
         r <- testResult.runCollect
@@ -1235,7 +1233,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
         val query = select(LPad(s, 5, pad))
 
         for {
-          r <- execute(query.to(identity)).runCollect
+          r <- execute(query).runCollect
         } yield r.head
       }
 
@@ -1250,7 +1248,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
         val query = select(RPad(s, 5, pad))
 
         for {
-          r <- execute(query.to(identity)).runCollect
+          r <- execute(query).runCollect
         } yield r.head
       }
 
@@ -1263,7 +1261,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
     testM("pg_client_encoding") {
       val query = select(PgClientEncoding())
 
-      val testResult = execute(query.to(identity))
+      val testResult = execute(query)
 
       val assertion = for {
         r <- testResult.runCollect
@@ -1277,7 +1275,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
 
       val expected = LocalDate.of(2013, 7, 15)
 
-      val testResult = execute(query.to(identity))
+      val testResult = execute(query)
 
       val assertion = for {
         r <- testResult.runCollect
@@ -1291,7 +1289,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
           MakeInterval(interval)
         )
         for {
-          r <- execute(query.to(identity)).runCollect
+          r <- execute(query).runCollect
         } yield r.head
       }
 
@@ -1308,7 +1306,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
     testM("make_time") {
       val query      = select(MakeTime(8, 15, 23.5))
       val expected   = LocalTime.parse("08:15:23.500")
-      val testResult = execute(query.to(identity))
+      val testResult = execute(query)
 
       val assertion = for {
         r <- testResult.runCollect
@@ -1319,7 +1317,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
     testM("make_timestamp") {
       val query      = select(MakeTimestamp(2013, 7, 15, 8, 15, 23.5))
       val expected   = LocalDateTime.parse("2013-07-15T08:15:23.500")
-      val testResult = execute(query.to(identity))
+      val testResult = execute(query)
 
       val assertion = for {
         r <- testResult.runCollect
@@ -1331,7 +1329,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
       def runTest(tz: Timestampz) = {
         val query = select(MakeTimestampz(tz))
         for {
-          r <- execute(query.to(identity)).runCollect
+          r <- execute(query).runCollect
         } yield r.head
       }
 
@@ -1351,7 +1349,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
     },
     testM("cannot compile a select without from clause if a table source is required") {
       //the following execute only compiles with 'from customers' clause
-      execute((select(CharLength(Customers.fName)) from customers).to(identity))
+      execute((select(CharLength(Customers.fName)) from customers))
 
       // imports for Left and Right are necessary to make the typeCheck macro expansion compile
       // TODO: clean this up when https://github.com/zio/zio/issues/4927 is resolved

--- a/postgres/src/test/scala/zio/sql/postgresql/FunctionDefSpec.scala
+++ b/postgres/src/test/scala/zio/sql/postgresql/FunctionDefSpec.scala
@@ -954,8 +954,8 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
         )
 
       val testResult = execute(query).map { case (id, fname, lname, verified, dob) =>
-          Customer(id, fname, lname, verified, dob)
-        }
+        Customer(id, fname, lname, verified, dob)
+      }
 
       val assertion = for {
         r <- testResult.runCollect

--- a/postgres/src/test/scala/zio/sql/postgresql/FunctionDefSpec.scala
+++ b/postgres/src/test/scala/zio/sql/postgresql/FunctionDefSpec.scala
@@ -954,10 +954,9 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
         )
 
       val testResult = execute(
-        query
-          .to{
-            case (id, fname, lname, verified, dob) => Customer(id, fname, lname, verified, dob)
-          }
+        query.to { case (id, fname, lname, verified, dob) =>
+          Customer(id, fname, lname, verified, dob)
+        }
       )
 
       val assertion = for {
@@ -1150,7 +1149,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
       val query = select(SetSeed(0.12) ++ Random() ++ Random()) from customers
 
       val randomTupleForSeed = (0.019967750719779076, 0.8378369929936333)
-      val testResult         = execute(query.to{ case (_, b, c) => (b, c) })
+      val testResult         = execute(query.to { case (_, b, c) => (b, c) })
 
       val assertion = for {
         r <- testResult.runCollect
@@ -1194,9 +1193,8 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
       val expectedRoundTripTimestamp = ZonedDateTime.of(2020, 11, 21, 19, 10, 25, 0, ZoneId.of(ZoneOffset.UTC.getId))
       val roundTripQuery             =
         select(createdString ++ createdTimestamp) from customers
-      val roundTripResults           = execute(roundTripQuery.to {
-        case row =>
-          (row._1, ZonedDateTime.parse(row._1), row._2)
+      val roundTripResults           = execute(roundTripQuery.to { case row =>
+        (row._1, ZonedDateTime.parse(row._1), row._2)
       })
       val roundTripExpected          = List(
         ("2020-11-21T19:10:25+00:00", ZonedDateTime.parse("2020-11-21T19:10:25+00:00"), expectedRoundTripTimestamp),

--- a/postgres/src/test/scala/zio/sql/postgresql/FunctionDefSpec.scala
+++ b/postgres/src/test/scala/zio/sql/postgresql/FunctionDefSpec.scala
@@ -46,7 +46,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
         "1+2+3"
       )
 
-      val testResult = execute(query.to[String, String](identity))
+      val testResult = execute(query.to(identity))
       collectAndCompare(expected, testResult)
     },
     testM("concat_ws #2 - combine columns") {
@@ -63,7 +63,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
         "JoseJoseWiggins"
       )
 
-      val testResult = execute(query.to[String, String](identity))
+      val testResult = execute(query.to(identity))
       collectAndCompare(expected, testResult)
     },
     testM("concat_ws #3 - combine columns and flat values") {
@@ -79,7 +79,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
         "Person: Jose Wiggins"
       )
 
-      val testResult = execute(query.to[String, String](identity))
+      val testResult = execute(query.to(identity))
       collectAndCompare(expected, testResult)
     },
     testM("concat_ws #3 - combine function calls together") {
@@ -97,7 +97,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
         "Name: Jose and Surname: Wiggins"
       )
 
-      val testResult = execute(query.to[String, String](identity))
+      val testResult = execute(query.to(identity))
       collectAndCompare(expected, testResult)
     },
     testM("isfinite") {
@@ -105,7 +105,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
 
       val expected: Boolean = true
 
-      val testResult = execute(query.to[Boolean, Boolean](identity))
+      val testResult = execute(query.to(identity))
 
       val assertion = for {
         r <- testResult.runCollect
@@ -118,7 +118,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
         val query    = select(Length("hello"))
         val expected = 5
 
-        val testResult = execute(query.to[Int, Int](identity))
+        val testResult = execute(query.to(identity))
 
         val assertion = for {
           r <- testResult.runCollect
@@ -131,7 +131,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
 
         val expected = "hello  "
 
-        val testResult = execute(query.to[String, String](identity))
+        val testResult = execute(query.to(identity))
 
         val assertion = for {
           r <- testResult.runCollect
@@ -144,7 +144,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
 
         val expected = "  hello"
 
-        val testResult = execute(query.to[String, String](identity))
+        val testResult = execute(query.to(identity))
 
         val assertion = for {
           r <- testResult.runCollect
@@ -157,7 +157,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
 
         val expected = 40
 
-        val testResult = execute(query.to[Int, Int](identity))
+        val testResult = execute(query.to(identity))
 
         val assertion = for {
           r <- testResult.runCollect
@@ -170,7 +170,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
 
         val expected = 3.141592653589793
 
-        val testResult = execute(query.to[Double, Double](identity))
+        val testResult = execute(query.to(identity))
 
         val assertion = for {
           r <- testResult.runCollect
@@ -192,7 +192,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
             "Person"
           )
 
-          val testResult = execute(query.to[String, String](identity))
+          val testResult = execute(query.to(identity))
           collectAndCompare(expected, testResult)
         },
         testM("format1") {
@@ -208,7 +208,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
             "Person: Jose"
           )
 
-          val testResult = execute(query.to[String, String](identity))
+          val testResult = execute(query.to(identity))
           collectAndCompare(expected, testResult)
         },
         testM("format2") {
@@ -224,7 +224,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
             "Person: Jose Wiggins"
           )
 
-          val testResult = execute(query.to[String, String](identity))
+          val testResult = execute(query.to(identity))
           collectAndCompare(expected, testResult)
         },
         testM("format3") {
@@ -242,7 +242,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
             s"""Person: Jose Wiggins with double quoted "identi fier" """
           )
 
-          val testResult = execute(query.to[String, String](identity))
+          val testResult = execute(query.to(identity))
           collectAndCompare(expected, testResult)
         },
         testM("format4") {
@@ -266,7 +266,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
             s"""Person: Jose Wiggins with null-literal 'FIXME: NULL' and non-null-literal 'literal' """
           )
 
-          val testResult = execute(query.to[String, String](identity))
+          val testResult = execute(query.to(identity))
           collectAndCompare(expected, testResult)
         },
         testM("format5") {
@@ -291,7 +291,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
             s"""Person: Jose Wiggins with more arguments than placeholders: identifier 'esoJ' """
           )
 
-          val testResult = execute(query.to[String, String](identity))
+          val testResult = execute(query.to(identity))
           collectAndCompare(expected, testResult)
         }
       )
@@ -301,7 +301,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
 
       val expected = 3.14159
 
-      val testResult = execute(query.to[Double, Double](identity))
+      val testResult = execute(query.to(identity))
 
       val assertion = for {
         r <- testResult.runCollect
@@ -314,7 +314,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
 
       val expected: Double = 5
 
-      val testResult = execute(query.to[Double, Double](identity))
+      val testResult = execute(query.to(identity))
 
       val assertion = for {
         r <- testResult.runCollect
@@ -327,7 +327,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
 
       val expected = 3.141592653589793
 
-      val testResult = execute(query.to[Double, Double](identity))
+      val testResult = execute(query.to(identity))
 
       val assertion = for {
         r <- testResult.runCollect
@@ -340,7 +340,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
 
       val expected = "ZioZioZio"
 
-      val testResult = execute(query.to[String, String](identity))
+      val testResult = execute(query.to(identity))
 
       val assertion = for {
         r <- testResult.runCollect
@@ -353,7 +353,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
 
       val expected = 0.5235987755982989
 
-      val testResult = execute(query.to[Double, Double](identity))
+      val testResult = execute(query.to(identity))
 
       val assertion = for {
         r <- testResult.runCollect
@@ -366,7 +366,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
 
       val expected = 1.0986122886681097
 
-      val testResult = execute(query.to[Double, Double](identity))
+      val testResult = execute(query.to(identity))
 
       val assertion = for {
         r <- testResult.runCollect
@@ -379,7 +379,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
 
       val expected = 1.4711276743037347
 
-      val testResult = execute(query.to[Double, Double](identity))
+      val testResult = execute(query.to(identity))
 
       val assertion = for {
         r <- testResult.runCollect
@@ -392,7 +392,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
 
       val expected = "dcba"
 
-      val testResult = execute(query.to[String, String](identity))
+      val testResult = execute(query.to(identity))
 
       val assertion = for {
         r <- testResult.runCollect
@@ -405,7 +405,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
 
       val expected = -1.0
 
-      val testResult = execute(query.to[Double, Double](identity))
+      val testResult = execute(query.to(identity))
 
       val assertion = for {
         r <- testResult.runCollect
@@ -418,7 +418,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
 
       val expected = 2.718281828459045
 
-      val testResult = execute(query.to[Double, Double](identity))
+      val testResult = execute(query.to(identity))
 
       val assertion = for {
         r <- testResult.runCollect
@@ -431,7 +431,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
 
       val expected = -4.0
 
-      val testResult = execute(query.to[Double, Double](identity))
+      val testResult = execute(query.to(identity))
 
       val assertion = for {
         r <- testResult.runCollect
@@ -444,7 +444,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
 
       val expected = (54.0, -53.0)
 
-      val testResult = execute(query.to[Double, Double, (Double, Double)]((a, b) => (a, b)))
+      val testResult = execute(query.to(value => (value._1, value._2)))
 
       val assertion = for {
         r <- testResult.runCollect
@@ -457,7 +457,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
 
       val expected = 0.8414709848078965
 
-      val testResult = execute(query.to[Double, Double](identity))
+      val testResult = execute(query.to(identity))
 
       val assertion = for {
         r <- testResult.runCollect
@@ -470,7 +470,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
 
       val expected = 0.5
 
-      val testResult = execute(query.to[Double, Double](identity))
+      val testResult = execute(query.to(identity))
 
       val assertion = for {
         r <- testResult.runCollect
@@ -483,7 +483,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
 
       val expected = "def"
 
-      val testResult = execute(query.to[String, String](identity))
+      val testResult = execute(query.to(identity))
 
       val assertion = for {
         r <- testResult.runCollect
@@ -494,7 +494,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
     testM("timeofday") {
       val query = select(TimeOfDay())
 
-      val testResult = execute(query.to[String, String](identity))
+      val testResult = execute(query.to(identity))
 
       val assertion =
         for {
@@ -509,7 +509,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
     testM("localtime") {
       val query = select(Localtime)
 
-      val testResult = execute(query.to[LocalTime, LocalTime](identity))
+      val testResult = execute(query.to(identity))
 
       val assertion = for {
         r <- testResult.runCollect
@@ -521,7 +521,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
       val precision = 0
       val query     = select(LocaltimeWithPrecision(precision))
 
-      val testResult = execute(query.to[LocalTime, LocalTime](identity))
+      val testResult = execute(query.to(identity))
 
       val assertion = for {
         r <- testResult.runCollect
@@ -532,7 +532,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
     testM("localtimestamp") {
       val query = select(Localtimestamp)
 
-      val testResult = execute(query.to[Instant, Instant](identity))
+      val testResult = execute(query.to(identity))
 
       val assertion =
         for {
@@ -548,7 +548,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
 
       val query = select(LocaltimestampWithPrecision(precision))
 
-      val testResult = execute(query.to[Instant, Instant](identity))
+      val testResult = execute(query.to(identity))
 
       val assertion =
         for {
@@ -562,7 +562,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
     testM("now") {
       val query = select(Now())
 
-      val testResult = execute(query.to[ZonedDateTime, ZonedDateTime](identity))
+      val testResult = execute(query.to(identity))
 
       val assertion =
         for {
@@ -576,7 +576,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
     testM("statement_timestamp") {
       val query = select(StatementTimestamp())
 
-      val testResult = execute(query.to[ZonedDateTime, ZonedDateTime](identity))
+      val testResult = execute(query.to(identity))
 
       val assertion =
         for {
@@ -590,7 +590,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
     testM("transaction_timestamp") {
       val query = select(TransactionTimestamp())
 
-      val testResult = execute(query.to[ZonedDateTime, ZonedDateTime](identity))
+      val testResult = execute(query.to(identity))
 
       val assertion =
         for {
@@ -604,7 +604,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
     testM("current_time") {
       val query = select(CurrentTime)
 
-      val testResult = execute(query.to[OffsetTime, OffsetTime](identity))
+      val testResult = execute(query.to(identity))
 
       val assertion =
         for {
@@ -622,7 +622,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
 
       val expected = "3adbbad1791fbae3ec908894c4963870"
 
-      val testResult = execute(query.to[String, String](identity))
+      val testResult = execute(query.to(identity))
 
       val assertion = for {
         r <- testResult.runCollect
@@ -643,7 +643,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
 
         val assertion = checkM(genTestString) { (testString) =>
           val query      = select(ParseIdent(testString))
-          val testResult = execute(query.to[String, String](identity))
+          val testResult = execute(query.to(identity))
 
           for {
             r <- testResult.runCollect
@@ -654,7 +654,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
       },
       testM("parseIdent fails with invalid identifier") {
         val query      = select(ParseIdent("\'\"SomeSchema\".someTable.\'"))
-        val testResult = execute(query.to[String, String](identity))
+        val testResult = execute(query.to(identity))
 
         val assertion = for {
           r <- testResult.runCollect.run
@@ -668,7 +668,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
 
       val expected = 11.0
 
-      val testResult = execute(query.to[Double, Double](identity))
+      val testResult = execute(query.to(identity))
 
       val assertion = for {
         r <- testResult.runCollect
@@ -681,7 +681,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
 
       val expected = "A"
 
-      val testResult = execute(query.to[String, String](identity))
+      val testResult = execute(query.to(identity))
 
       val assertion = for {
         r <- testResult.runCollect
@@ -694,7 +694,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
 
       val expected = LocalDate.now()
 
-      val testResult = execute(query.to[LocalDate, LocalDate](identity))
+      val testResult = execute(query.to(identity))
 
       val assertion = for {
         r <- testResult.runCollect
@@ -707,7 +707,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
 
       val expected = "Hi Thomas"
 
-      val testResult = execute(query.to[String, String](identity))
+      val testResult = execute(query.to(identity))
 
       val assertion = for {
         r <- testResult.runCollect
@@ -720,7 +720,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
 
       val expected = 8.41
 
-      val testResult = execute(query.to[Double, Double](identity))
+      val testResult = execute(query.to(identity))
 
       val assertion = for {
         r <- testResult.runCollect
@@ -733,7 +733,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
 
       val expected = "7fffffff"
 
-      val testResult = execute(query.to[String, String](identity))
+      val testResult = execute(query.to(identity))
 
       val assertion = for {
         r <- testResult.runCollect
@@ -746,7 +746,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
 
       val expected = "SGVsbG8sIFdvcmxkIQ=="
 
-      val testResult = execute(query.to[String, String](identity))
+      val testResult = execute(query.to(identity))
 
       val assertion = for {
         r <- testResult.runCollect
@@ -759,7 +759,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
 
       val expected = Chunk.fromArray("Hello, World!".getBytes)
 
-      val testResult = execute(query.to[Chunk[Byte], Chunk[Byte]](identity))
+      val testResult = execute(query.to(identity))
 
       val assertion = for {
         r <- testResult.runCollect
@@ -772,7 +772,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
 
       val expected = 42d
 
-      val testResult = execute(query.to[Double, Double](identity))
+      val testResult = execute(query.to(identity))
 
       val assertion = for {
         r <- testResult.runCollect
@@ -785,7 +785,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
 
       val expected = 10.81
 
-      val testResult = execute(query.to[Double, Double](identity))
+      val testResult = execute(query.to(identity))
 
       val assertion = for {
         r <- testResult.runCollect
@@ -798,7 +798,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
 
       val expected = 1
 
-      val testResult = execute(query.to[Int, Int](identity))
+      val testResult = execute(query.to(identity))
 
       val assertion = for {
         r <- testResult.runCollect
@@ -811,7 +811,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
 
       val expected = -1
 
-      val testResult = execute(query.to[Int, Int](identity))
+      val testResult = execute(query.to(identity))
 
       val assertion = for {
         r <- testResult.runCollect
@@ -824,7 +824,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
 
       val expected = 0
 
-      val testResult = execute(query.to[Int, Int](identity))
+      val testResult = execute(query.to(identity))
 
       val assertion = for {
         r <- testResult.runCollect
@@ -837,7 +837,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
 
       val expected = 343.000000000000000
 
-      val testResult = execute(query.to[Double, Double](identity))
+      val testResult = execute(query.to(identity))
 
       val assertion = for {
         r <- testResult.runCollect
@@ -850,7 +850,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
 
       val expected = 5
 
-      val testResult = execute(query.to[Int, Int](identity))
+      val testResult = execute(query.to(identity))
 
       val assertion = for {
         r <- testResult.runCollect
@@ -863,7 +863,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
 
       val expected = -3.0
 
-      val testResult = execute(query.to[Double, Double](identity))
+      val testResult = execute(query.to(identity))
 
       val assertion = for {
         r <- testResult.runCollect
@@ -876,7 +876,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
 
       val expected = "a2x5"
 
-      val testResult = execute(query.to[String, String](identity))
+      val testResult = execute(query.to(identity))
 
       val assertion = for {
         r <- testResult.runCollect
@@ -889,7 +889,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
 
       val expected = "ab"
 
-      val testResult = execute(query.to[String, String](identity))
+      val testResult = execute(query.to(identity))
 
       val assertion = for {
         r <- testResult.runCollect
@@ -902,7 +902,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
 
       val expected = "de"
 
-      val testResult = execute(query.to[String, String](identity))
+      val testResult = execute(query.to(identity))
 
       val assertion = for {
         r <- testResult.runCollect
@@ -915,7 +915,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
 
       val expected = 0.7853981634
 
-      val testResult = execute(query.to[Double, Double](identity))
+      val testResult = execute(query.to(identity))
 
       val assertion = for {
         r <- testResult.runCollect
@@ -928,7 +928,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
 
       val expected = 2
 
-      val testResult = execute(query.to[Int, Int](identity))
+      val testResult = execute(query.to(identity))
 
       val assertion = for {
         r <- testResult.runCollect
@@ -955,9 +955,9 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
 
       val testResult = execute(
         query
-          .to[UUID, String, String, Boolean, LocalDate, Customer]((id, fname, lname, verified, dob) =>
-            Customer(id, fname, lname, verified, dob)
-          )
+          .to{
+            case (id, fname, lname, verified, dob) => Customer(id, fname, lname, verified, dob)
+          }
       )
 
       val assertion = for {
@@ -971,7 +971,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
 
       val expected = "ronald"
 
-      val testResult = execute(query.to[String, String](identity))
+      val testResult = execute(query.to(identity))
 
       val assertion = for {
         r <- testResult.runCollect
@@ -984,7 +984,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
 
       val expected = "lower"
 
-      val testResult = execute(query.to[String, String](identity))
+      val testResult = execute(query.to(identity))
 
       val assertion = for {
         r <- testResult.runCollect
@@ -997,7 +997,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
 
       val expected = 5
 
-      val testResult = execute(query.to[Int, Int](identity))
+      val testResult = execute(query.to(identity))
 
       val assertion = for {
         r <- testResult.runCollect
@@ -1010,7 +1010,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
 
       val expected = 120
 
-      val testResult = execute(query.to[Int, Int](identity))
+      val testResult = execute(query.to(identity))
 
       val assertion = for {
         r <- testResult.runCollect
@@ -1023,7 +1023,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
 
       val expected = "RONALD"
 
-      val testResult = execute(query.to[String, String](identity))
+      val testResult = execute(query.to(identity))
 
       val assertion = for {
         r <- testResult.runCollect
@@ -1036,7 +1036,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
 
       val expected = 3
 
-      val testResult = execute(query.to[Int, Int](identity))
+      val testResult = execute(query.to(identity))
 
       val assertion = for {
         r <- testResult.runCollect
@@ -1049,7 +1049,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
 
       val expected = 1.0000000000051035
 
-      val testResult = execute(query.to[Double, Double](identity))
+      val testResult = execute(query.to(identity))
 
       val assertion = for {
         r <- testResult.runCollect
@@ -1062,7 +1062,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
 
       val expected = 21d
 
-      val testResult = execute(query.to[Double, Double](identity))
+      val testResult = execute(query.to(identity))
 
       val assertion = for {
         r <- testResult.runCollect
@@ -1075,7 +1075,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
 
       val expected = 23562d
 
-      val testResult = execute(query.to[Double, Double](identity))
+      val testResult = execute(query.to(identity))
 
       val assertion = for {
         r <- testResult.runCollect
@@ -1088,7 +1088,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
 
       val expected = 4d
 
-      val testResult = execute(query.to[Double, Double](identity))
+      val testResult = execute(query.to(identity))
 
       val assertion = for {
         r <- testResult.runCollect
@@ -1101,7 +1101,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
 
       val expected = 28.64788975654116
 
-      val testResult = execute(query.to[Double, Double](identity))
+      val testResult = execute(query.to(identity))
 
       val assertion = for {
         r <- testResult.runCollect
@@ -1114,7 +1114,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
 
       val expected = 2d
 
-      val testResult = execute(query.to[Double, Double](identity))
+      val testResult = execute(query.to(identity))
 
       val assertion = for {
         r <- testResult.runCollect
@@ -1127,7 +1127,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
 
       val expected = 120
 
-      val testResult = execute(query.to[Int, Int](identity))
+      val testResult = execute(query.to(identity))
 
       val assertion = for {
         r <- testResult.runCollect
@@ -1138,7 +1138,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
     testM("random") {
       val query = select(Random())
 
-      val testResult = execute(query.to[Double, Double](identity))
+      val testResult = execute(query.to(identity))
 
       val assertion = for {
         r <- testResult.runCollect
@@ -1150,7 +1150,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
       val query = select(SetSeed(0.12) ++ Random() ++ Random()) from customers
 
       val randomTupleForSeed = (0.019967750719779076, 0.8378369929936333)
-      val testResult         = execute(query.to[Unit, Double, Double, (Double, Double)]((_, b, c) => (b, c)))
+      val testResult         = execute(query.to{ case (_, b, c) => (b, c) })
 
       val assertion = for {
         r <- testResult.runCollect
@@ -1164,7 +1164,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
 
       val expected = Seq("RonaldRussell", "TerrenceNoel", "MilaPaterso", "AlanaMurray", "JoseWiggins")
 
-      val result = execute(query.to[String, String](identity))
+      val result = execute(query.to(identity))
 
       val assertion = for {
         r <- result.runCollect
@@ -1178,7 +1178,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
 
       val expected = Seq(6, 8, 4, 5, 4)
 
-      val result = execute(query.to[Int, Int](identity))
+      val result = execute(query.to(identity))
 
       val assertion = for {
         r <- result.runCollect
@@ -1189,12 +1189,12 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
     testM("to_timestamp") {
       val query      = select(ToTimestamp(1284352323L))
       val expected   = ZonedDateTime.of(2010, 9, 13, 4, 32, 3, 0, ZoneId.of(ZoneOffset.UTC.getId))
-      val testResult = execute(query.to[ZonedDateTime, ZonedDateTime](identity))
+      val testResult = execute(query.to(identity))
 
       val expectedRoundTripTimestamp = ZonedDateTime.of(2020, 11, 21, 19, 10, 25, 0, ZoneId.of(ZoneOffset.UTC.getId))
       val roundTripQuery             =
         select(createdString ++ createdTimestamp) from customers
-      val roundTripResults           = execute(roundTripQuery.to[String, ZonedDateTime, (String, ZonedDateTime, ZonedDateTime)] {
+      val roundTripResults           = execute(roundTripQuery.to {
         case row =>
           (row._1, ZonedDateTime.parse(row._1), row._2)
       })
@@ -1222,7 +1222,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
       val expected = ("Russe_", "special ::__::")
 
       val testResult =
-        execute(query.to[String, String, (String, String)] { case row =>
+        execute(query.to { case row =>
           (row._1, row._2)
         })
 
@@ -1237,7 +1237,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
         val query = select(LPad(s, 5, pad))
 
         for {
-          r <- execute(query.to[String, String](identity)).runCollect
+          r <- execute(query.to(identity)).runCollect
         } yield r.head
       }
 
@@ -1252,7 +1252,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
         val query = select(RPad(s, 5, pad))
 
         for {
-          r <- execute(query.to[String, String](identity)).runCollect
+          r <- execute(query.to(identity)).runCollect
         } yield r.head
       }
 
@@ -1265,7 +1265,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
     testM("pg_client_encoding") {
       val query = select(PgClientEncoding())
 
-      val testResult = execute(query.to[String, String](identity))
+      val testResult = execute(query.to(identity))
 
       val assertion = for {
         r <- testResult.runCollect
@@ -1279,7 +1279,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
 
       val expected = LocalDate.of(2013, 7, 15)
 
-      val testResult = execute(query.to[LocalDate, LocalDate](identity))
+      val testResult = execute(query.to(identity))
 
       val assertion = for {
         r <- testResult.runCollect
@@ -1293,7 +1293,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
           MakeInterval(interval)
         )
         for {
-          r <- execute(query.to[Interval, Interval](identity)).runCollect
+          r <- execute(query.to(identity)).runCollect
         } yield r.head
       }
 
@@ -1310,7 +1310,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
     testM("make_time") {
       val query      = select(MakeTime(8, 15, 23.5))
       val expected   = LocalTime.parse("08:15:23.500")
-      val testResult = execute(query.to[LocalTime, LocalTime](identity))
+      val testResult = execute(query.to(identity))
 
       val assertion = for {
         r <- testResult.runCollect
@@ -1321,7 +1321,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
     testM("make_timestamp") {
       val query      = select(MakeTimestamp(2013, 7, 15, 8, 15, 23.5))
       val expected   = LocalDateTime.parse("2013-07-15T08:15:23.500")
-      val testResult = execute(query.to[LocalDateTime, LocalDateTime](identity))
+      val testResult = execute(query.to(identity))
 
       val assertion = for {
         r <- testResult.runCollect
@@ -1333,7 +1333,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
       def runTest(tz: Timestampz) = {
         val query = select(MakeTimestampz(tz))
         for {
-          r <- execute(query.to[Timestampz, Timestampz](identity)).runCollect
+          r <- execute(query.to(identity)).runCollect
         } yield r.head
       }
 
@@ -1353,7 +1353,7 @@ object FunctionDefSpec extends PostgresRunnableSpec with ShopSchema {
     },
     testM("cannot compile a select without from clause if a table source is required") {
       //the following execute only compiles with 'from customers' clause
-      execute((select(CharLength(Customers.fName)) from customers).to[Int, Int](identity))
+      execute((select(CharLength(Customers.fName)) from customers).to(identity))
 
       // imports for Left and Right are necessary to make the typeCheck macro expansion compile
       // TODO: clean this up when https://github.com/zio/zio/issues/4927 is resolved

--- a/postgres/src/test/scala/zio/sql/postgresql/PostgresModuleSpec.scala
+++ b/postgres/src/test/scala/zio/sql/postgresql/PostgresModuleSpec.scala
@@ -37,8 +37,8 @@ object PostgresModuleSpec extends PostgresRunnableSpec with ShopSchema {
       )
 
     val testResult = execute(query).map { case row =>
-          Customer(row._1, row._2, row._3, row._4, row._5)
-        }
+      Customer(row._1, row._2, row._3, row._4, row._5)
+    }
 
     val assertion = for {
       r <- testResult.runCollect
@@ -88,8 +88,8 @@ object PostgresModuleSpec extends PostgresRunnableSpec with ShopSchema {
         )
 
       val testResult = execute(query).map { case row =>
-            Customer(row._1, row._2, row._3, row._4)
-          }
+        Customer(row._1, row._2, row._3, row._4)
+      }
 
       val assertion = for {
         r <- testResult.runCollect
@@ -297,8 +297,8 @@ object PostgresModuleSpec extends PostgresRunnableSpec with ShopSchema {
       val query = select(fName ++ lName ++ (subquery as "Count")).from(customers)
 
       val result = execute(query).map { case row =>
-          Row(row._1, row._2, row._3)
-        }
+        Row(row._1, row._2, row._3)
+      }
 
       val assertion = for {
         r <- result.runCollect
@@ -320,8 +320,9 @@ object PostgresModuleSpec extends PostgresRunnableSpec with ShopSchema {
         )
       )
 
-      val testResult = execute(query).map { case (uuid, firstName, lastName, dob) => Customer(uuid, firstName, lastName, dob) }
-      
+      val testResult = execute(query).map { case (uuid, firstName, lastName, dob) =>
+        Customer(uuid, firstName, lastName, dob)
+      }
 
       val assertion = for {
         r <- testResult.runCollect

--- a/postgres/src/test/scala/zio/sql/postgresql/PostgresModuleSpec.scala
+++ b/postgres/src/test/scala/zio/sql/postgresql/PostgresModuleSpec.scala
@@ -388,19 +388,17 @@ object PostgresModuleSpec extends PostgresRunnableSpec with ShopSchema {
         */
 
         import AggregationDef._
-        import Ordering._
 
         val expected = List(6,5,5,5,4)
 
         val query = select(fkCustomerId ++ Count(orderId))
           .from(orders)
-          //.groupBy(fkCustomerId)
+          .groupBy(fkCustomerId)
+          .orderBy(Ordering.Desc(Count(orderId)))
 
-        val actual = execute(query.to[Long, Int](_.toInt)).runCollect.map(_.toList)
+        val actual = execute(query.to[UUID, Long, Int]((_: UUID, count: Long) => count.toInt)).runCollect.map(_.toList)
 
         assertM(actual)(equalTo(expected))
-
-        ???
     },
     testM("insert - 1 rows into customers") {
 

--- a/postgres/src/test/scala/zio/sql/postgresql/PostgresModuleSpec.scala
+++ b/postgres/src/test/scala/zio/sql/postgresql/PostgresModuleSpec.scala
@@ -379,6 +379,29 @@ object PostgresModuleSpec extends PostgresRunnableSpec with ShopSchema {
 
       assertion.mapErrorCause(cause => Cause.stackless(cause.untraced))
     },
+    testM("group by / order by order is correct") {    
+      /**
+        select customer_id, count(id)
+          from orders
+          group by customer_id
+          order by count(id) desc
+        */
+
+        import AggregationDef._
+        import Ordering._
+
+        val expected = List(6,5,5,5,4)
+
+        val query = select(fkCustomerId ++ Count(orderId))
+          .from(orders)
+          //.groupBy(fkCustomerId)
+
+        val actual = execute(query.to[Long, Int](_.toInt)).runCollect.map(_.toList)
+
+        assertM(actual)(equalTo(expected))
+
+        ???
+    },
     testM("insert - 1 rows into customers") {
 
       /**

--- a/postgres/src/test/scala/zio/sql/postgresql/PostgresModuleSpec.scala
+++ b/postgres/src/test/scala/zio/sql/postgresql/PostgresModuleSpec.scala
@@ -38,7 +38,7 @@ object PostgresModuleSpec extends PostgresRunnableSpec with ShopSchema {
 
     val testResult = execute(
       query
-        .to[UUID, String, String, Boolean, LocalDate, Customer] { case row =>
+        .to[Customer] { case row =>
           Customer(row._1, row._2, row._3, row._4, row._5)
         }
     )
@@ -92,7 +92,7 @@ object PostgresModuleSpec extends PostgresRunnableSpec with ShopSchema {
 
       val testResult = execute(
         query
-          .to[UUID, String, String, LocalDate, Customer] { case row =>
+          .to[Customer] { case row =>
             Customer(row._1, row._2, row._3, row._4)
           }
       )
@@ -175,10 +175,7 @@ object PostgresModuleSpec extends PostgresRunnableSpec with ShopSchema {
         )
 
       val testResult = execute(
-        query
-          .to[UUID, String, String, LocalDate, Customer] { case row =>
-            Customer(row._1, row._2, row._3, row._4)
-          }
+        query.to(Customer tupled _)
       )
 
       val assertion = for {
@@ -192,7 +189,7 @@ object PostgresModuleSpec extends PostgresRunnableSpec with ShopSchema {
 
       val expected = 5L
 
-      val result = execute(query.to[Long, Long](identity))
+      val result = execute(query.to(identity))
 
       for {
         r <- result.runCollect
@@ -203,40 +200,35 @@ object PostgresModuleSpec extends PostgresRunnableSpec with ShopSchema {
 
       case class Row(firstName: String, lastName: String, orderDate: LocalDate)
 
-      val expected = Seq(
-        Row("Ronald", "Russell", LocalDate.parse("2019-03-25")),
-        Row("Ronald", "Russell", LocalDate.parse("2018-06-04")),
-        Row("Alana", "Murray", LocalDate.parse("2019-08-19")),
-        Row("Jose", "Wiggins", LocalDate.parse("2019-08-30")),
-        Row("Jose", "Wiggins", LocalDate.parse("2019-03-07")),
-        Row("Ronald", "Russell", LocalDate.parse("2020-03-19")),
-        Row("Alana", "Murray", LocalDate.parse("2020-05-11")),
-        Row("Alana", "Murray", LocalDate.parse("2019-02-21")),
-        Row("Ronald", "Russell", LocalDate.parse("2018-05-06")),
-        Row("Mila", "Paterso", LocalDate.parse("2019-02-11")),
-        Row("Terrence", "Noel", LocalDate.parse("2019-10-12")),
-        Row("Ronald", "Russell", LocalDate.parse("2019-01-29")),
-        Row("Terrence", "Noel", LocalDate.parse("2019-02-10")),
-        Row("Ronald", "Russell", LocalDate.parse("2019-09-27")),
-        Row("Alana", "Murray", LocalDate.parse("2018-11-13")),
-        Row("Jose", "Wiggins", LocalDate.parse("2020-01-15")),
-        Row("Terrence", "Noel", LocalDate.parse("2018-07-10")),
-        Row("Mila", "Paterso", LocalDate.parse("2019-08-01")),
-        Row("Alana", "Murray", LocalDate.parse("2019-12-08")),
-        Row("Mila", "Paterso", LocalDate.parse("2019-11-04")),
-        Row("Mila", "Paterso", LocalDate.parse("2018-10-14")),
-        Row("Terrence", "Noel", LocalDate.parse("2020-04-05")),
-        Row("Jose", "Wiggins", LocalDate.parse("2019-01-23")),
-        Row("Terrence", "Noel", LocalDate.parse("2019-05-14")),
-        Row("Mila", "Paterso", LocalDate.parse("2020-04-30"))
+      val expected = List(
+        ("Ronald", "Russell", LocalDate.parse("2019-03-25")),
+        ("Ronald", "Russell", LocalDate.parse("2018-06-04")),
+        ("Alana", "Murray", LocalDate.parse("2019-08-19")),
+        ("Jose", "Wiggins", LocalDate.parse("2019-08-30")),
+        ("Jose", "Wiggins", LocalDate.parse("2019-03-07")),
+        ("Ronald", "Russell", LocalDate.parse("2020-03-19")),
+        ("Alana", "Murray", LocalDate.parse("2020-05-11")),
+        ("Alana", "Murray", LocalDate.parse("2019-02-21")),
+        ("Ronald", "Russell", LocalDate.parse("2018-05-06")),
+        ("Mila", "Paterso", LocalDate.parse("2019-02-11")),
+        ("Terrence", "Noel", LocalDate.parse("2019-10-12")),
+        ("Ronald", "Russell", LocalDate.parse("2019-01-29")),
+        ("Terrence", "Noel", LocalDate.parse("2019-02-10")),
+        ("Ronald", "Russell", LocalDate.parse("2019-09-27")),
+        ("Alana", "Murray", LocalDate.parse("2018-11-13")),
+        ("Jose", "Wiggins", LocalDate.parse("2020-01-15")),
+        ("Terrence", "Noel", LocalDate.parse("2018-07-10")),
+        ("Mila", "Paterso", LocalDate.parse("2019-08-01")),
+        ("Alana", "Murray", LocalDate.parse("2019-12-08")),
+        ("Mila", "Paterso", LocalDate.parse("2019-11-04")),
+        ("Mila", "Paterso", LocalDate.parse("2018-10-14")),
+        ("Terrence", "Noel", LocalDate.parse("2020-04-05")),
+        ("Jose", "Wiggins", LocalDate.parse("2019-01-23")),
+        ("Terrence", "Noel", LocalDate.parse("2019-05-14")),
+        ("Mila", "Paterso", LocalDate.parse("2020-04-30"))
       )
 
-      val result = execute(
-        query
-          .to[String, String, LocalDate, Row] { case row =>
-            Row(row._1, row._2, row._3)
-          }
-      )
+      val result = execute(query)
 
       val assertion = for {
         r <- result.runCollect
@@ -281,9 +273,7 @@ object PostgresModuleSpec extends PostgresRunnableSpec with ShopSchema {
 
       val result = execute(
         query
-          .to[UUID, String, String, LocalDate, Row] { case row =>
-            Row(row._1, row._2, row._3, row._4)
-          }
+          .to(Row tupled _)
       )
 
       val assertion = for {
@@ -319,7 +309,7 @@ object PostgresModuleSpec extends PostgresRunnableSpec with ShopSchema {
 
       val result = execute(
         query
-          .to[String, String, Long, Row] { case row =>
+          .to{ case row =>
             Row(row._1, row._2, row._3)
           }
       )
@@ -346,9 +336,7 @@ object PostgresModuleSpec extends PostgresRunnableSpec with ShopSchema {
 
       val testResult = execute(
         query
-          .to[UUID, String, String, LocalDate, Customer] { case row =>
-            Customer(row._1, row._2, row._3, row._4)
-          }
+          .to { case (uuid, firstName, lastName, dob) => Customer(uuid, firstName, lastName, dob) }
       )
 
       val assertion = for {
@@ -401,7 +389,7 @@ object PostgresModuleSpec extends PostgresRunnableSpec with ShopSchema {
         .from(orders)
         .groupBy(fkCustomerId)
 
-      val actual = execute(query.to[UUID, String](_.toString())).runCollect.map(_.toList)
+      val actual = execute(query.to(_.toString())).runCollect.map(_.toList)
 
       assertM(actual)(equalTo(expected))
     },
@@ -423,7 +411,7 @@ object PostgresModuleSpec extends PostgresRunnableSpec with ShopSchema {
         .groupBy(fkCustomerId)
         .orderBy(Ordering.Desc(Count(orderId)))
 
-      val actual = execute(query.to[UUID, Long, Int]((_: UUID, count: Long) => count.toInt)).runCollect.map(_.toList)
+      val actual = execute(query.to(arg => arg._2.toInt)).runCollect.map(_.toList)
 
       assertM(actual)(equalTo(expected))
     },

--- a/postgres/src/test/scala/zio/sql/postgresql/ShopSchema.scala
+++ b/postgres/src/test/scala/zio/sql/postgresql/ShopSchema.scala
@@ -64,7 +64,7 @@ trait ShopSchema extends Jdbc { self =>
       select(orderDetailsOrderId ++ orderDetailsProductId ++ unitPrice).from(orderDetails).asTable("derived")
 
     val (derivedOrderId, derivedProductId, derivedUnitPrice) = orderDetailsDerived.columns
-    val orderDateDerivedTable                                          = customers
+    val orderDateDerivedTable                                = customers
       .subselect(orderDate)
       .from(orders)
       .limit(1)

--- a/postgres/src/test/scala/zio/sql/postgresql/ShopSchema.scala
+++ b/postgres/src/test/scala/zio/sql/postgresql/ShopSchema.scala
@@ -13,7 +13,7 @@ trait ShopSchema extends Jdbc { self =>
       (uuid("id") ++ string("first_name") ++ string("last_name") ++ (localDate("dob") @@ nullable))
         .table("persons")
 
-    val personId :*: fName :*: lName :*: dob :*: _ = persons.columns
+    val (personId, fName, lName, dob) = persons.columns
   }
 
   object Customers     {
@@ -24,25 +24,25 @@ trait ShopSchema extends Jdbc { self =>
       ) ++ string("created_timestamp_string") ++ zonedDateTime("created_timestamp"))
         .table("customers")
 
-    val customerId :*: dob :*: fName :*: lName :*: verified :*: createdString :*: createdTimestamp :*: _ =
+    val (customerId, dob, fName, lName, verified, createdString, createdTimestamp) =
       customers.columns
   }
   object Orders        {
     val orders = (uuid("id") ++ uuid("customer_id") ++ localDate("order_date")).table("orders")
 
-    val orderId :*: fkCustomerId :*: orderDate :*: _ = orders.columns
+    val (orderId, fkCustomerId, orderDate) = orders.columns
   }
   object Products      {
     val products =
       (uuid("id") ++ string("name") ++ string("description") ++ string("image_url")).table("products")
 
-    val productId :*: productName :*: description :*: imageURL :*: _ = products.columns
+    val (productId, productName, description, imageURL) = products.columns
   }
   object ProductPrices {
     val productPrices =
       (uuid("product_id") ++ offsetDateTime("effective") ++ bigDecimal("price")).table("product_prices")
 
-    val fkProductId :*: effective :*: price :*: _ = productPrices.columns
+    val (fkProductId, effective, price) = productPrices.columns
   }
 
   object OrderDetails {
@@ -52,7 +52,7 @@ trait ShopSchema extends Jdbc { self =>
           "order_details"
         )
 
-    val orderDetailsOrderId :*: orderDetailsProductId :*: quantity :*: unitPrice :*: _ = orderDetails.columns
+    val (orderDetailsOrderId, orderDetailsProductId, quantity, unitPrice) = orderDetails.columns
   }
 
   object DerivedTables {
@@ -63,7 +63,7 @@ trait ShopSchema extends Jdbc { self =>
     val orderDetailsDerived =
       select(orderDetailsOrderId ++ orderDetailsProductId ++ unitPrice).from(orderDetails).asTable("derived")
 
-    val derivedOrderId :*: derivedProductId :*: derivedUnitPrice :*: _ = orderDetailsDerived.columns
+    val (derivedOrderId, derivedProductId, derivedUnitPrice) = orderDetailsDerived.columns
     val orderDateDerivedTable                                          = customers
       .subselect(orderDate)
       .from(orders)
@@ -72,6 +72,6 @@ trait ShopSchema extends Jdbc { self =>
       .orderBy(Ordering.Desc(orderDate))
       .asTable("derived")
 
-    val orderDateDerived :*: _ = orderDateDerivedTable.columns
+    val orderDateDerived = orderDateDerivedTable.columns
   }
 }

--- a/postgres/src/test/scala/zio/sql/postgresql/ShopSchema.scala
+++ b/postgres/src/test/scala/zio/sql/postgresql/ShopSchema.scala
@@ -5,6 +5,17 @@ import zio.sql.Jdbc
 trait ShopSchema extends Jdbc { self =>
   import self.ColumnSet._
 
+  object Persons {
+
+    import ColumnSetAspect._
+
+    val persons =
+      (uuid("id") ++ string("first_name") ++ string("last_name") ++ (localDate("dob") @@ nullable))
+        .table("persons")
+
+    val personId :*: fName :*: lName :*: dob :*: _ = persons.columns
+  }
+
   object Customers     {
     //https://github.com/zio/zio-sql/issues/320 Once Insert is supported, we can remove created_timestamp_string
     val customers =

--- a/postgres/src/test/scala/zio/sql/postgresql/TransactionSpec.scala
+++ b/postgres/src/test/scala/zio/sql/postgresql/TransactionSpec.scala
@@ -1,7 +1,5 @@
 package zio.sql.postgresql
 
-import java.util.UUID
-
 import zio._
 import zio.test.Assertion._
 import zio.test._
@@ -39,11 +37,11 @@ object TransactionSpec extends PostgresRunnableSpec with ShopSchema {
       val deleteQuery = deleteFrom(customers).where(verified === false)
 
       val result = (for {
-        allCustomersCount       <- execute(query.to(identity[UUID](_))).runCount.toManaged_
+        allCustomersCount       <- execute(query).runCount.toManaged_
         _                       <- execute(
                                      ZTransaction(deleteQuery) *> ZTransaction.fail(new Exception("this is error")) *> ZTransaction(query)
                                    ).catchAllCause(_ => ZManaged.succeed("continue"))
-        remainingCustomersCount <- execute(query.to(identity[UUID](_))).runCount.toManaged_
+        remainingCustomersCount <- execute(query).runCount.toManaged_
       } yield (allCustomersCount, remainingCustomersCount)).use(ZIO.succeed(_))
 
       assertM(result)(equalTo((5L, 5L))).mapErrorCause(cause => Cause.stackless(cause.untraced))
@@ -55,9 +53,9 @@ object TransactionSpec extends PostgresRunnableSpec with ShopSchema {
       val tx = ZTransaction(deleteQuery)
 
       val result = (for {
-        allCustomersCount       <- execute(query.to(identity[UUID](_))).runCount.toManaged_
+        allCustomersCount       <- execute(query).runCount.toManaged_
         _                       <- execute(tx)
-        remainingCustomersCount <- execute(query.to(identity[UUID](_))).runCount.toManaged_
+        remainingCustomersCount <- execute(query).runCount.toManaged_
       } yield (allCustomersCount, remainingCustomersCount)).use(ZIO.succeed(_))
 
       assertM(result)(equalTo((5L, 4L))).mapErrorCause(cause => Cause.stackless(cause.untraced))

--- a/sqlserver/src/main/scala/zio/sql/sqlserver/SqlServerModule.scala
+++ b/sqlserver/src/main/scala/zio/sql/sqlserver/SqlServerModule.scala
@@ -251,7 +251,7 @@ trait SqlServerModule extends Jdbc { self =>
         case Read.Mapped(read, _) => buildReadString(read.asInstanceOf[Read[Out]])
 
         //todo offset (needs orderBy, must use fetch _instead_ of top)
-        case read0 @ Read.Subselect(_, _, _, _, _, _, _, _, _) =>
+        case read0 @ Read.Subselect(_, _, _, _, _, _, _, _) =>
           object Dummy {
             type F
             type Repr
@@ -280,7 +280,7 @@ trait SqlServerModule extends Jdbc { self =>
               buildExpr(whereExpr)
           }
           groupByExprs match {
-            case _ :: _ =>
+            case Read.ExprSet.ExprCons(_, _) =>
               builder.append(" group by ")
               buildExprList(groupByExprs)
 
@@ -290,7 +290,7 @@ trait SqlServerModule extends Jdbc { self =>
                   builder.append(" having ")
                   buildExpr(havingExpr)
               }
-            case Nil    => ()
+            case Read.ExprSet.NoExpr    => ()
           }
           orderByExprs match {
             case _ :: _ =>
@@ -309,17 +309,17 @@ trait SqlServerModule extends Jdbc { self =>
           val _ = builder.append(" (").append(values.mkString(",")).append(") ") //todo fix needs escaping
       }
 
-    def buildExprList(expr: List[Expr[_, _, _]]): Unit               =
+    def buildExprList(expr: Read.ExprSet[_]): Unit               =
       expr match {
-        case head :: tail =>
+        case Read.ExprSet.ExprCons(head, tail) => 
           buildExpr(head)
           tail match {
-            case _ :: _ =>
+            case Read.ExprSet.ExprCons(_, _) =>
               builder.append(", ")
               buildExprList(tail)
-            case Nil    => ()
+            case Read.ExprSet.NoExpr    => ()
           }
-        case Nil          => ()
+        case Read.ExprSet.NoExpr    => ()
       }
     def buildOrderingList(expr: List[Ordering[Expr[_, _, _]]]): Unit =
       expr match {

--- a/sqlserver/src/main/scala/zio/sql/sqlserver/SqlServerModule.scala
+++ b/sqlserver/src/main/scala/zio/sql/sqlserver/SqlServerModule.scala
@@ -290,7 +290,7 @@ trait SqlServerModule extends Jdbc { self =>
                   builder.append(" having ")
                   buildExpr(havingExpr)
               }
-            case Read.ExprSet.NoExpr    => ()
+            case Read.ExprSet.NoExpr         => ()
           }
           orderByExprs match {
             case _ :: _ =>
@@ -309,17 +309,17 @@ trait SqlServerModule extends Jdbc { self =>
           val _ = builder.append(" (").append(values.mkString(",")).append(") ") //todo fix needs escaping
       }
 
-    def buildExprList(expr: Read.ExprSet[_]): Unit               =
+    def buildExprList(expr: Read.ExprSet[_]): Unit                   =
       expr match {
-        case Read.ExprSet.ExprCons(head, tail) => 
+        case Read.ExprSet.ExprCons(head, tail) =>
           buildExpr(head)
-          tail match {
+          tail.asInstanceOf[Read.ExprSet[_]] match {
             case Read.ExprSet.ExprCons(_, _) =>
               builder.append(", ")
-              buildExprList(tail)
-            case Read.ExprSet.NoExpr    => ()
+              buildExprList(tail.asInstanceOf[Read.ExprSet[_]])
+            case Read.ExprSet.NoExpr         => ()
           }
-        case Read.ExprSet.NoExpr    => ()
+        case Read.ExprSet.NoExpr               => ()
       }
     def buildOrderingList(expr: List[Ordering[Expr[_, _, _]]]): Unit =
       expr match {

--- a/sqlserver/src/main/scala/zio/sql/sqlserver/SqlServerModule.scala
+++ b/sqlserver/src/main/scala/zio/sql/sqlserver/SqlServerModule.scala
@@ -248,6 +248,8 @@ trait SqlServerModule extends Jdbc { self =>
 
     def buildReadString[Out](read: Read[Out]): Unit =
       read match {
+        case Read.Mapped(read, _) => buildReadString(read.asInstanceOf[Read[Out]])
+
         //todo offset (needs orderBy, must use fetch _instead_ of top)
         case read0 @ Read.Subselect(_, _, _, _, _, _, _, _) =>
           object Dummy {

--- a/sqlserver/src/main/scala/zio/sql/sqlserver/SqlServerModule.scala
+++ b/sqlserver/src/main/scala/zio/sql/sqlserver/SqlServerModule.scala
@@ -248,8 +248,6 @@ trait SqlServerModule extends Jdbc { self =>
 
     def buildReadString[Out](read: Read[Out]): Unit =
       read match {
-        case Read.Mapped(read, _) => buildReadString(read.asInstanceOf[Read[Out]])
-
         //todo offset (needs orderBy, must use fetch _instead_ of top)
         case read0 @ Read.Subselect(_, _, _, _, _, _, _, _) =>
           object Dummy {

--- a/sqlserver/src/main/scala/zio/sql/sqlserver/SqlServerModule.scala
+++ b/sqlserver/src/main/scala/zio/sql/sqlserver/SqlServerModule.scala
@@ -251,7 +251,7 @@ trait SqlServerModule extends Jdbc { self =>
         case Read.Mapped(read, _) => buildReadString(read.asInstanceOf[Read[Out]])
 
         //todo offset (needs orderBy, must use fetch _instead_ of top)
-        case read0 @ Read.Subselect(_, _, _, _, _, _, _, _) =>
+        case read0 @ Read.Subselect(_, _, _, _, _, _, _, _, _) =>
           object Dummy {
             type F
             type Repr
@@ -279,10 +279,10 @@ trait SqlServerModule extends Jdbc { self =>
               builder.append(" where ")
               buildExpr(whereExpr)
           }
-          groupBy match {
+          groupByExprs match {
             case _ :: _ =>
               builder.append(" group by ")
-              buildExprList(groupBy)
+              buildExprList(groupByExprs)
 
               havingExpr match {
                 case Expr.Literal(true) => ()
@@ -292,10 +292,10 @@ trait SqlServerModule extends Jdbc { self =>
               }
             case Nil    => ()
           }
-          orderBy match {
+          orderByExprs match {
             case _ :: _ =>
               builder.append(" order by ")
-              buildOrderingList(orderBy)
+              buildOrderingList(orderByExprs)
             case Nil    => ()
           }
 

--- a/sqlserver/src/test/scala/zio/sql/sqlserver/DbSchema.scala
+++ b/sqlserver/src/test/scala/zio/sql/sqlserver/DbSchema.scala
@@ -11,26 +11,26 @@ trait DbSchema extends Jdbc { self =>
       (uuid("id") ++ string("first_name") ++ string("last_name") ++ boolean("verified") ++ localDate("dob"))
         .table("customers")
 
-    val customerId :*: fName :*: lName :*: verified :*: dob :*: _ =
+    val (customerId, fName, lName, verified, dob) =
       customers.columns
 
     val orders = (uuid("id") ++ uuid("customer_id") ++ localDate("order_date")).table("orders")
 
-    val orderId :*: fkCustomerId :*: orderDate :*: _ = orders.columns
+    val (orderId, fkCustomerId, orderDate) = orders.columns
 
     val productPrices =
       (uuid("product_id") ++ offsetDateTime("effective") ++ bigDecimal("price")).table("product_prices")
 
-    val fkProductId :*: effective :*: price :*: _ = productPrices.columns
+    val (fkProductId, effective, price) = productPrices.columns
 
     val orderDetails =
       (uuid("order_id") ++ uuid("product_id") ++ int("quantity") ++ bigDecimal("unit_price")).table("order_details")
 
-    val orderDetailsId :*: productId :*: quantity :*: unitPrice :*: _ = orderDetails.columns
+    val (orderDetailsId, productId, quantity, unitPrice) = orderDetails.columns
 
     val orderDetailsDerived = select(orderDetailsId ++ productId ++ unitPrice).from(orderDetails).asTable("derived")
 
-    val derivedOrderId :*: derivedProductId :*: derivedUnitPrice :*: _ = orderDetailsDerived.columns
+    val (derivedOrderId, derivedProductId, derivedUnitPrice) = orderDetailsDerived.columns
 
     val orderDateDerivedTable = customers
       .subselect(orderDate)
@@ -40,6 +40,6 @@ trait DbSchema extends Jdbc { self =>
       .orderBy(Ordering.Desc(orderDate))
       .asTable("derived")
 
-    val orderDateDerived :*: _ = orderDateDerivedTable.columns
+    val orderDateDerived = orderDateDerivedTable.columns
   }
 }

--- a/sqlserver/src/test/scala/zio/sql/sqlserver/SqlServerModuleSpec.scala
+++ b/sqlserver/src/test/scala/zio/sql/sqlserver/SqlServerModuleSpec.scala
@@ -14,7 +14,9 @@ object PostgresModuleSpec extends SqlServerRunnableSpec with DbSchema {
   import AggregationDef._
   import DbSchema._
 
-  private def customerSelectJoseAssertion(condition: Expr[_, customers.TableType, Boolean]) = {
+  private def customerSelectJoseAssertion[F: Features.IsNotAggregated](
+    condition: Expr[F, customers.TableType, Boolean]
+  ) = {
     case class Customer(id: UUID, fname: String, lname: String, verified: Boolean, dateOfBirth: LocalDate)
 
     val query =

--- a/sqlserver/src/test/scala/zio/sql/sqlserver/SqlServerModuleSpec.scala
+++ b/sqlserver/src/test/scala/zio/sql/sqlserver/SqlServerModuleSpec.scala
@@ -33,11 +33,9 @@ object PostgresModuleSpec extends SqlServerRunnableSpec with DbSchema {
         )
       )
 
-    val testResult = execute(
-      query.to { case row =>
+    val testResult = execute(query).map { row =>
         Customer(row._1, row._2, row._3, row._4, row._5)
       }
-    )
 
     val assertion = for {
       r <- testResult.runCollect
@@ -86,11 +84,9 @@ object PostgresModuleSpec extends SqlServerRunnableSpec with DbSchema {
           )
         )
 
-      val testResult = execute(
-        query.to { case row =>
+      val testResult = execute(query).map { case row =>
           Customer(row._1, row._2, row._3, row._4)
         }
-      )
 
       val assertion = for {
         r <- testResult.runCollect
@@ -137,11 +133,9 @@ object PostgresModuleSpec extends SqlServerRunnableSpec with DbSchema {
           )
         )
 
-      val testResult = execute(
-        query.to { case row =>
+      val testResult = execute(query).map { case row =>
           Customer(row._1, row._2, row._3, row._4)
         }
-      )
 
       val assertion = for {
         r <- testResult.runCollect
@@ -154,7 +148,7 @@ object PostgresModuleSpec extends SqlServerRunnableSpec with DbSchema {
 
       val expected = 5L
 
-      val result = execute(query.to(identity))
+      val result = execute(query)
 
       for {
         r <- result.runCollect
@@ -185,11 +179,9 @@ object PostgresModuleSpec extends SqlServerRunnableSpec with DbSchema {
 
       val query = select(fName ++ lName ++ (subquery as "Count")).from(customers)
 
-      val result = execute(
-        query.to { case row =>
+      val result = execute(query).map { case row =>
           Row(row._1, row._2, row._3)
         }
-      )
 
       val assertion = for {
         r <- result.runCollect
@@ -247,11 +239,9 @@ object PostgresModuleSpec extends SqlServerRunnableSpec with DbSchema {
         Row.create("5883CB62-D792-4EE3-ACBC-FE85B6BAA998", "D5137D3A-894A-4109-9986-E982541B434F", 55.0000)
       )
 
-      //TODO try to support apply
-      //val result = execute(query.to[Row](Row.apply))
-      val result = execute(query.to { case (id, productId, price) =>
+      val result = execute(query).map { case (id, productId, price) =>
         Row(id, productId, price)
-      })
+      }
 
       val assertion = for {
         r <- result.runCollect
@@ -332,11 +322,9 @@ object PostgresModuleSpec extends SqlServerRunnableSpec with DbSchema {
         Row("0a48ffb0-ec61-4147-af56-fc4dbca8de0a", "f35b0053-855b-4145-abe1-dc62bc1fdb96", 6.0)
       )
 
-      val result = execute(
-        query.to { case row =>
+      val result = execute(query).map { case row =>
           Row(row._1, row._2, row._3)
         }
-      )
 
       val assertion = for {
         r <- result.runCollect
@@ -379,11 +367,9 @@ object PostgresModuleSpec extends SqlServerRunnableSpec with DbSchema {
           .from(customers.crossApply(orderDateDerivedTable))
           .orderBy(Ordering.Desc(orderDateDerived))
 
-      val result = execute(
-        query.to { case row =>
+      val result = execute(query).map { case row =>
           Row(row._1, row._2, row._3, row._4)
         }
-      )
 
       val assertion = for {
         r <- result.runCollect
@@ -406,15 +392,13 @@ object PostgresModuleSpec extends SqlServerRunnableSpec with DbSchema {
       val subquery =
         subselect[customers.TableType](orderDate).from(orders).where(customerId === fkCustomerId).asTable("ooo")
 
-      val orderDateDerived :*: _ = subquery.columns
+      val orderDateDerived = subquery.columns
 
       val query = select(fName ++ lName ++ orderDateDerived).from(customers.crossApply(subquery))
 
-      val result = execute(
-        query.to { case row =>
+      val result = execute(query).map { case row =>
           CustomerAndDateRow(row._1, row._2, row._3)
-        }
-      )
+      }
 
       val assertion = for {
         r <- result.runCollect
@@ -427,15 +411,13 @@ object PostgresModuleSpec extends SqlServerRunnableSpec with DbSchema {
       val subquery =
         customers.subselect(orderDate).from(orders).where(customerId === fkCustomerId).asTable("ooo")
 
-      val orderDateDerived :*: _ = subquery.columns
+      val orderDateDerived = subquery.columns
 
       val query = select(fName ++ lName ++ orderDateDerived).from(customers.crossApply(subquery))
 
-      val result = execute(
-        query.to { case row =>
+      val result = execute(query).map { case row =>
           CustomerAndDateRow(row._1, row._2, row._3)
-        }
-      )
+      }
 
       val assertion = for {
         r <- result.runCollect
@@ -448,15 +430,13 @@ object PostgresModuleSpec extends SqlServerRunnableSpec with DbSchema {
       val subquery =
         subselectFrom(customers)(orderDate).from(orders).where(customerId === fkCustomerId).asTable("ooo")
 
-      val orderDateDerived :*: _ = subquery.columns
+      val orderDateDerived = subquery.columns
 
       val query = select(fName ++ lName ++ orderDateDerived).from(customers.crossApply(subquery))
 
-      val result = execute(
-        query.to { case row =>
+      val result = execute(query).map { case row =>
           CustomerAndDateRow(row._1, row._2, row._3)
-        }
-      )
+      }
 
       val assertion = for {
         r <- result.runCollect
@@ -469,15 +449,13 @@ object PostgresModuleSpec extends SqlServerRunnableSpec with DbSchema {
       val subquery =
         subselect[customers.TableType](orderDate).from(orders).where(customerId === fkCustomerId).asTable("ooo")
 
-      val orderDateDerived :*: _ = subquery.columns
+      val orderDateDerived = subquery.columns
 
       val query = select(fName ++ lName ++ orderDateDerived).from(customers.outerApply(subquery))
 
-      val result = execute(
-        query.to { case row =>
+      val result = execute(query).map { case row =>
           CustomerAndDateRow(row._1, row._2, row._3)
-        }
-      )
+      }
 
       val assertion = for {
         r <- result.runCollect
@@ -518,11 +496,9 @@ object PostgresModuleSpec extends SqlServerRunnableSpec with DbSchema {
         Row("Mila", "Paterso", LocalDate.parse("2020-04-30"))
       )
 
-      val result = execute(
-        query.to { case row =>
+      val result = execute(query).map { case row =>
           Row(row._1, row._2, row._3)
-        }
-      )
+      }
 
       val assertion = for {
         r <- result.runCollect

--- a/sqlserver/src/test/scala/zio/sql/sqlserver/SqlServerModuleSpec.scala
+++ b/sqlserver/src/test/scala/zio/sql/sqlserver/SqlServerModuleSpec.scala
@@ -34,10 +34,9 @@ object PostgresModuleSpec extends SqlServerRunnableSpec with DbSchema {
       )
 
     val testResult = execute(
-      query
-        .to { case row =>
-          Customer(row._1, row._2, row._3, row._4, row._5)
-        }
+      query.to { case row =>
+        Customer(row._1, row._2, row._3, row._4, row._5)
+      }
     )
 
     val assertion = for {
@@ -88,10 +87,9 @@ object PostgresModuleSpec extends SqlServerRunnableSpec with DbSchema {
         )
 
       val testResult = execute(
-        query
-          .to { case row =>
-            Customer(row._1, row._2, row._3, row._4)
-          }
+        query.to { case row =>
+          Customer(row._1, row._2, row._3, row._4)
+        }
       )
 
       val assertion = for {
@@ -140,10 +138,9 @@ object PostgresModuleSpec extends SqlServerRunnableSpec with DbSchema {
         )
 
       val testResult = execute(
-        query
-          .to { case row =>
-            Customer(row._1, row._2, row._3, row._4)
-          }
+        query.to { case row =>
+          Customer(row._1, row._2, row._3, row._4)
+        }
       )
 
       val assertion = for {
@@ -189,10 +186,9 @@ object PostgresModuleSpec extends SqlServerRunnableSpec with DbSchema {
       val query = select(fName ++ lName ++ (subquery as "Count")).from(customers)
 
       val result = execute(
-        query
-          .to { case row =>
-            Row(row._1, row._2, row._3)
-          }
+        query.to { case row =>
+          Row(row._1, row._2, row._3)
+        }
       )
 
       val assertion = for {
@@ -253,8 +249,8 @@ object PostgresModuleSpec extends SqlServerRunnableSpec with DbSchema {
 
       //TODO try to support apply
       //val result = execute(query.to[Row](Row.apply))
-      val result = execute(query.to{
-        case (id, productId, price) => Row(id, productId, price)
+      val result = execute(query.to { case (id, productId, price) =>
+        Row(id, productId, price)
       })
 
       val assertion = for {
@@ -337,10 +333,9 @@ object PostgresModuleSpec extends SqlServerRunnableSpec with DbSchema {
       )
 
       val result = execute(
-        query
-          .to { case row =>
-            Row(row._1, row._2, row._3)
-          }
+        query.to { case row =>
+          Row(row._1, row._2, row._3)
+        }
       )
 
       val assertion = for {
@@ -385,10 +380,9 @@ object PostgresModuleSpec extends SqlServerRunnableSpec with DbSchema {
           .orderBy(Ordering.Desc(orderDateDerived))
 
       val result = execute(
-        query
-          .to { case row =>
-            Row(row._1, row._2, row._3, row._4)
-          }
+        query.to { case row =>
+          Row(row._1, row._2, row._3, row._4)
+        }
       )
 
       val assertion = for {
@@ -417,10 +411,9 @@ object PostgresModuleSpec extends SqlServerRunnableSpec with DbSchema {
       val query = select(fName ++ lName ++ orderDateDerived).from(customers.crossApply(subquery))
 
       val result = execute(
-        query
-          .to { case row =>
-            CustomerAndDateRow(row._1, row._2, row._3)
-          }
+        query.to { case row =>
+          CustomerAndDateRow(row._1, row._2, row._3)
+        }
       )
 
       val assertion = for {
@@ -439,10 +432,9 @@ object PostgresModuleSpec extends SqlServerRunnableSpec with DbSchema {
       val query = select(fName ++ lName ++ orderDateDerived).from(customers.crossApply(subquery))
 
       val result = execute(
-        query
-          .to { case row =>
-            CustomerAndDateRow(row._1, row._2, row._3)
-          }
+        query.to { case row =>
+          CustomerAndDateRow(row._1, row._2, row._3)
+        }
       )
 
       val assertion = for {
@@ -461,10 +453,9 @@ object PostgresModuleSpec extends SqlServerRunnableSpec with DbSchema {
       val query = select(fName ++ lName ++ orderDateDerived).from(customers.crossApply(subquery))
 
       val result = execute(
-        query
-          .to { case row =>
-            CustomerAndDateRow(row._1, row._2, row._3)
-          }
+        query.to { case row =>
+          CustomerAndDateRow(row._1, row._2, row._3)
+        }
       )
 
       val assertion = for {
@@ -483,10 +474,9 @@ object PostgresModuleSpec extends SqlServerRunnableSpec with DbSchema {
       val query = select(fName ++ lName ++ orderDateDerived).from(customers.outerApply(subquery))
 
       val result = execute(
-        query
-          .to { case row =>
-            CustomerAndDateRow(row._1, row._2, row._3)
-          }
+        query.to { case row =>
+          CustomerAndDateRow(row._1, row._2, row._3)
+        }
       )
 
       val assertion = for {
@@ -529,10 +519,9 @@ object PostgresModuleSpec extends SqlServerRunnableSpec with DbSchema {
       )
 
       val result = execute(
-        query
-          .to { case row =>
-            Row(row._1, row._2, row._3)
-          }
+        query.to { case row =>
+          Row(row._1, row._2, row._3)
+        }
       )
 
       val assertion = for {

--- a/sqlserver/src/test/scala/zio/sql/sqlserver/SqlServerModuleSpec.scala
+++ b/sqlserver/src/test/scala/zio/sql/sqlserver/SqlServerModuleSpec.scala
@@ -34,8 +34,8 @@ object PostgresModuleSpec extends SqlServerRunnableSpec with DbSchema {
       )
 
     val testResult = execute(query).map { row =>
-        Customer(row._1, row._2, row._3, row._4, row._5)
-      }
+      Customer(row._1, row._2, row._3, row._4, row._5)
+    }
 
     val assertion = for {
       r <- testResult.runCollect
@@ -85,8 +85,8 @@ object PostgresModuleSpec extends SqlServerRunnableSpec with DbSchema {
         )
 
       val testResult = execute(query).map { case row =>
-          Customer(row._1, row._2, row._3, row._4)
-        }
+        Customer(row._1, row._2, row._3, row._4)
+      }
 
       val assertion = for {
         r <- testResult.runCollect
@@ -134,8 +134,8 @@ object PostgresModuleSpec extends SqlServerRunnableSpec with DbSchema {
         )
 
       val testResult = execute(query).map { case row =>
-          Customer(row._1, row._2, row._3, row._4)
-        }
+        Customer(row._1, row._2, row._3, row._4)
+      }
 
       val assertion = for {
         r <- testResult.runCollect
@@ -180,8 +180,8 @@ object PostgresModuleSpec extends SqlServerRunnableSpec with DbSchema {
       val query = select(fName ++ lName ++ (subquery as "Count")).from(customers)
 
       val result = execute(query).map { case row =>
-          Row(row._1, row._2, row._3)
-        }
+        Row(row._1, row._2, row._3)
+      }
 
       val assertion = for {
         r <- result.runCollect
@@ -323,8 +323,8 @@ object PostgresModuleSpec extends SqlServerRunnableSpec with DbSchema {
       )
 
       val result = execute(query).map { case row =>
-          Row(row._1, row._2, row._3)
-        }
+        Row(row._1, row._2, row._3)
+      }
 
       val assertion = for {
         r <- result.runCollect
@@ -368,8 +368,8 @@ object PostgresModuleSpec extends SqlServerRunnableSpec with DbSchema {
           .orderBy(Ordering.Desc(orderDateDerived))
 
       val result = execute(query).map { case row =>
-          Row(row._1, row._2, row._3, row._4)
-        }
+        Row(row._1, row._2, row._3, row._4)
+      }
 
       val assertion = for {
         r <- result.runCollect
@@ -397,7 +397,7 @@ object PostgresModuleSpec extends SqlServerRunnableSpec with DbSchema {
       val query = select(fName ++ lName ++ orderDateDerived).from(customers.crossApply(subquery))
 
       val result = execute(query).map { case row =>
-          CustomerAndDateRow(row._1, row._2, row._3)
+        CustomerAndDateRow(row._1, row._2, row._3)
       }
 
       val assertion = for {
@@ -416,7 +416,7 @@ object PostgresModuleSpec extends SqlServerRunnableSpec with DbSchema {
       val query = select(fName ++ lName ++ orderDateDerived).from(customers.crossApply(subquery))
 
       val result = execute(query).map { case row =>
-          CustomerAndDateRow(row._1, row._2, row._3)
+        CustomerAndDateRow(row._1, row._2, row._3)
       }
 
       val assertion = for {
@@ -435,7 +435,7 @@ object PostgresModuleSpec extends SqlServerRunnableSpec with DbSchema {
       val query = select(fName ++ lName ++ orderDateDerived).from(customers.crossApply(subquery))
 
       val result = execute(query).map { case row =>
-          CustomerAndDateRow(row._1, row._2, row._3)
+        CustomerAndDateRow(row._1, row._2, row._3)
       }
 
       val assertion = for {
@@ -454,7 +454,7 @@ object PostgresModuleSpec extends SqlServerRunnableSpec with DbSchema {
       val query = select(fName ++ lName ++ orderDateDerived).from(customers.outerApply(subquery))
 
       val result = execute(query).map { case row =>
-          CustomerAndDateRow(row._1, row._2, row._3)
+        CustomerAndDateRow(row._1, row._2, row._3)
       }
 
       val assertion = for {
@@ -497,7 +497,7 @@ object PostgresModuleSpec extends SqlServerRunnableSpec with DbSchema {
       )
 
       val result = execute(query).map { case row =>
-          Row(row._1, row._2, row._3)
+        Row(row._1, row._2, row._3)
       }
 
       val assertion = for {

--- a/sqlserver/src/test/scala/zio/sql/sqlserver/SqlServerModuleSpec.scala
+++ b/sqlserver/src/test/scala/zio/sql/sqlserver/SqlServerModuleSpec.scala
@@ -35,7 +35,7 @@ object PostgresModuleSpec extends SqlServerRunnableSpec with DbSchema {
 
     val testResult = execute(
       query
-        .to[UUID, String, String, Boolean, LocalDate, Customer] { case row =>
+        .to { case row =>
           Customer(row._1, row._2, row._3, row._4, row._5)
         }
     )
@@ -89,7 +89,7 @@ object PostgresModuleSpec extends SqlServerRunnableSpec with DbSchema {
 
       val testResult = execute(
         query
-          .to[UUID, String, String, LocalDate, Customer] { case row =>
+          .to { case row =>
             Customer(row._1, row._2, row._3, row._4)
           }
       )
@@ -141,7 +141,7 @@ object PostgresModuleSpec extends SqlServerRunnableSpec with DbSchema {
 
       val testResult = execute(
         query
-          .to[UUID, String, String, LocalDate, Customer] { case row =>
+          .to { case row =>
             Customer(row._1, row._2, row._3, row._4)
           }
       )
@@ -157,7 +157,7 @@ object PostgresModuleSpec extends SqlServerRunnableSpec with DbSchema {
 
       val expected = 5L
 
-      val result = execute(query.to[Long, Long](identity))
+      val result = execute(query.to(identity))
 
       for {
         r <- result.runCollect
@@ -190,7 +190,7 @@ object PostgresModuleSpec extends SqlServerRunnableSpec with DbSchema {
 
       val result = execute(
         query
-          .to[String, String, Long, Row] { case row =>
+          .to { case row =>
             Row(row._1, row._2, row._3)
           }
       )
@@ -216,42 +216,46 @@ object PostgresModuleSpec extends SqlServerRunnableSpec with DbSchema {
           unitPrice > select(Avg(price)).from(productPrices)
         )
 
-      case class Row(orderId: UUID, productId: UUID, unitPrice: BigDecimal)
+      case class Row(orderId: UUID, productId: UUID, unitPrice: scala.math.BigDecimal)
 
       object Row {
-        def apply(orderId: String, productId: String, unitPrice: BigDecimal): Row =
+        def create(orderId: String, productId: String, unitPrice: BigDecimal): Row =
           new Row(UUID.fromString(orderId), UUID.fromString(productId), unitPrice)
       }
 
       val expected = Seq(
-        Row("04912093-CC2E-46AC-B64C-1BD7BB7758C3", "105A2701-EF93-4E25-81AB-8952CC7D9DAA", 74.0000),
-        Row("9022DD0D-06D6-4A43-9121-2993FC7712A1", "105A2701-EF93-4E25-81AB-8952CC7D9DAA", 74.0000),
-        Row("38D66D44-3CFA-488A-AC77-30277751418F", "105A2701-EF93-4E25-81AB-8952CC7D9DAA", 74.0000),
-        Row("7B2627D5-0150-44DF-9171-3462E20797EE", "105A2701-EF93-4E25-81AB-8952CC7D9DAA", 74.0000),
-        Row("62CD4109-3E5D-40CC-8188-3899FC1F8BDF", "105A2701-EF93-4E25-81AB-8952CC7D9DAA", 72.7200),
-        Row("9473A0BC-396A-4936-96B0-3EEA922AF36B", "105A2701-EF93-4E25-81AB-8952CC7D9DAA", 80.0000),
-        Row("B8BAC18D-769F-48ED-809D-4B6C0E4D1795", "105A2701-EF93-4E25-81AB-8952CC7D9DAA", 67.2700),
-        Row("BEBBFE4D-4EC3-4389-BDC2-50E9EAC2B15B", "105A2701-EF93-4E25-81AB-8952CC7D9DAA", 67.2700),
-        Row("742D45A0-E81A-41CE-95AD-55B4CABBA258", "105A2701-EF93-4E25-81AB-8952CC7D9DAA", 67.2700),
-        Row("618AA21F-700B-4CA7-933C-67066CF4CD97", "105A2701-EF93-4E25-81AB-8952CC7D9DAA", 74.0000),
-        Row("606DA090-DD33-4A77-8746-6ED0E8443AB2", "105A2701-EF93-4E25-81AB-8952CC7D9DAA", 67.2700),
-        Row("FD0FA8D4-E1A0-4369-BE07-945450DB5D36", "105A2701-EF93-4E25-81AB-8952CC7D9DAA", 80.0000),
-        Row("876B6034-B33C-4497-81EE-B4E8742164C2", "105A2701-EF93-4E25-81AB-8952CC7D9DAA", 74.0000),
-        Row("91CAA28A-A5FE-40D7-979C-BD6A128D0418", "105A2701-EF93-4E25-81AB-8952CC7D9DAA", 74.0000),
-        Row("2C3FC180-D0DF-4D7B-A271-E6CCD2440393", "105A2701-EF93-4E25-81AB-8952CC7D9DAA", 70.0000),
-        Row("763A7C39-833F-4EE8-9939-E80DFDBFC0FC", "105A2701-EF93-4E25-81AB-8952CC7D9DAA", 80.0000),
-        Row("5011D206-8EFF-42C4-868E-F1A625E1F186", "105A2701-EF93-4E25-81AB-8952CC7D9DAA", 74.0000),
-        Row("0A48FFB0-EC61-4147-AF56-FC4DBCA8DE0A", "105A2701-EF93-4E25-81AB-8952CC7D9DAA", 74.0000),
-        Row("A243FA42-817A-44EC-8B67-22193D212D82", "D5137D3A-894A-4109-9986-E982541B434F", 45.4500),
-        Row("62CD4109-3E5D-40CC-8188-3899FC1F8BDF", "D5137D3A-894A-4109-9986-E982541B434F", 50.0000),
-        Row("9473A0BC-396A-4936-96B0-3EEA922AF36B", "D5137D3A-894A-4109-9986-E982541B434F", 55.0000),
-        Row("852E2DC9-4EC3-4225-A6F7-4F42F8FF728E", "D5137D3A-894A-4109-9986-E982541B434F", 45.4500),
-        Row("D6D8DDDC-4B0B-4D74-8EDC-A54E9B7F35F7", "D5137D3A-894A-4109-9986-E982541B434F", 50.0000),
-        Row("2C3FC180-D0DF-4D7B-A271-E6CCD2440393", "D5137D3A-894A-4109-9986-E982541B434F", 50.0000),
-        Row("5883CB62-D792-4EE3-ACBC-FE85B6BAA998", "D5137D3A-894A-4109-9986-E982541B434F", 55.0000)
+        Row.create("04912093-CC2E-46AC-B64C-1BD7BB7758C3", "105A2701-EF93-4E25-81AB-8952CC7D9DAA", 74.0000),
+        Row.create("9022DD0D-06D6-4A43-9121-2993FC7712A1", "105A2701-EF93-4E25-81AB-8952CC7D9DAA", 74.0000),
+        Row.create("38D66D44-3CFA-488A-AC77-30277751418F", "105A2701-EF93-4E25-81AB-8952CC7D9DAA", 74.0000),
+        Row.create("7B2627D5-0150-44DF-9171-3462E20797EE", "105A2701-EF93-4E25-81AB-8952CC7D9DAA", 74.0000),
+        Row.create("62CD4109-3E5D-40CC-8188-3899FC1F8BDF", "105A2701-EF93-4E25-81AB-8952CC7D9DAA", 72.7200),
+        Row.create("9473A0BC-396A-4936-96B0-3EEA922AF36B", "105A2701-EF93-4E25-81AB-8952CC7D9DAA", 80.0000),
+        Row.create("B8BAC18D-769F-48ED-809D-4B6C0E4D1795", "105A2701-EF93-4E25-81AB-8952CC7D9DAA", 67.2700),
+        Row.create("BEBBFE4D-4EC3-4389-BDC2-50E9EAC2B15B", "105A2701-EF93-4E25-81AB-8952CC7D9DAA", 67.2700),
+        Row.create("742D45A0-E81A-41CE-95AD-55B4CABBA258", "105A2701-EF93-4E25-81AB-8952CC7D9DAA", 67.2700),
+        Row.create("618AA21F-700B-4CA7-933C-67066CF4CD97", "105A2701-EF93-4E25-81AB-8952CC7D9DAA", 74.0000),
+        Row.create("606DA090-DD33-4A77-8746-6ED0E8443AB2", "105A2701-EF93-4E25-81AB-8952CC7D9DAA", 67.2700),
+        Row.create("FD0FA8D4-E1A0-4369-BE07-945450DB5D36", "105A2701-EF93-4E25-81AB-8952CC7D9DAA", 80.0000),
+        Row.create("876B6034-B33C-4497-81EE-B4E8742164C2", "105A2701-EF93-4E25-81AB-8952CC7D9DAA", 74.0000),
+        Row.create("91CAA28A-A5FE-40D7-979C-BD6A128D0418", "105A2701-EF93-4E25-81AB-8952CC7D9DAA", 74.0000),
+        Row.create("2C3FC180-D0DF-4D7B-A271-E6CCD2440393", "105A2701-EF93-4E25-81AB-8952CC7D9DAA", 70.0000),
+        Row.create("763A7C39-833F-4EE8-9939-E80DFDBFC0FC", "105A2701-EF93-4E25-81AB-8952CC7D9DAA", 80.0000),
+        Row.create("5011D206-8EFF-42C4-868E-F1A625E1F186", "105A2701-EF93-4E25-81AB-8952CC7D9DAA", 74.0000),
+        Row.create("0A48FFB0-EC61-4147-AF56-FC4DBCA8DE0A", "105A2701-EF93-4E25-81AB-8952CC7D9DAA", 74.0000),
+        Row.create("A243FA42-817A-44EC-8B67-22193D212D82", "D5137D3A-894A-4109-9986-E982541B434F", 45.4500),
+        Row.create("62CD4109-3E5D-40CC-8188-3899FC1F8BDF", "D5137D3A-894A-4109-9986-E982541B434F", 50.0000),
+        Row.create("9473A0BC-396A-4936-96B0-3EEA922AF36B", "D5137D3A-894A-4109-9986-E982541B434F", 55.0000),
+        Row.create("852E2DC9-4EC3-4225-A6F7-4F42F8FF728E", "D5137D3A-894A-4109-9986-E982541B434F", 45.4500),
+        Row.create("D6D8DDDC-4B0B-4D74-8EDC-A54E9B7F35F7", "D5137D3A-894A-4109-9986-E982541B434F", 50.0000),
+        Row.create("2C3FC180-D0DF-4D7B-A271-E6CCD2440393", "D5137D3A-894A-4109-9986-E982541B434F", 50.0000),
+        Row.create("5883CB62-D792-4EE3-ACBC-FE85B6BAA998", "D5137D3A-894A-4109-9986-E982541B434F", 55.0000)
       )
 
-      val result = execute(query.to[UUID, UUID, BigDecimal, Row](Row.apply))
+      //TODO try to support apply
+      //val result = execute(query.to[Row](Row.apply))
+      val result = execute(query.to{
+        case (id, productId, price) => Row(id, productId, price)
+      })
 
       val assertion = for {
         r <- result.runCollect
@@ -334,7 +338,7 @@ object PostgresModuleSpec extends SqlServerRunnableSpec with DbSchema {
 
       val result = execute(
         query
-          .to[UUID, UUID, BigDecimal, Row] { case row =>
+          .to { case row =>
             Row(row._1, row._2, row._3)
           }
       )
@@ -382,7 +386,7 @@ object PostgresModuleSpec extends SqlServerRunnableSpec with DbSchema {
 
       val result = execute(
         query
-          .to[UUID, String, String, LocalDate, Row] { case row =>
+          .to { case row =>
             Row(row._1, row._2, row._3, row._4)
           }
       )
@@ -414,7 +418,7 @@ object PostgresModuleSpec extends SqlServerRunnableSpec with DbSchema {
 
       val result = execute(
         query
-          .to[String, String, LocalDate, CustomerAndDateRow] { case row =>
+          .to { case row =>
             CustomerAndDateRow(row._1, row._2, row._3)
           }
       )
@@ -436,7 +440,7 @@ object PostgresModuleSpec extends SqlServerRunnableSpec with DbSchema {
 
       val result = execute(
         query
-          .to[String, String, LocalDate, CustomerAndDateRow] { case row =>
+          .to { case row =>
             CustomerAndDateRow(row._1, row._2, row._3)
           }
       )
@@ -458,7 +462,7 @@ object PostgresModuleSpec extends SqlServerRunnableSpec with DbSchema {
 
       val result = execute(
         query
-          .to[String, String, LocalDate, CustomerAndDateRow] { case row =>
+          .to { case row =>
             CustomerAndDateRow(row._1, row._2, row._3)
           }
       )
@@ -480,7 +484,7 @@ object PostgresModuleSpec extends SqlServerRunnableSpec with DbSchema {
 
       val result = execute(
         query
-          .to[String, String, LocalDate, CustomerAndDateRow] { case row =>
+          .to { case row =>
             CustomerAndDateRow(row._1, row._2, row._3)
           }
       )
@@ -526,7 +530,7 @@ object PostgresModuleSpec extends SqlServerRunnableSpec with DbSchema {
 
       val result = execute(
         query
-          .to[String, String, LocalDate, Row] { case row =>
+          .to { case row =>
             Row(row._1, row._2, row._3)
           }
       )


### PR DESCRIPTION
@jdegoes @jczuchnowski 
Changes:

1. Generating of columns from meta model no longer needs :*: operator to separate column exprs and trailing unit. Call to `columns` on `table` simply returns a flat tuple of `Expr`.

Old way 
```
val personsTable = (string("name") ++ int("age")).table("persons")
val name :*: age :*: _ = personsTable.columns
```
New way
```
val personsTable = (string("name") ++ int("age")).table("persons")
val (name, age) = personsTable.columns
```

2.  When executing queries we no longer need to specify all the type parameters:

Old way
```
query
    .to[UUID, String, String, LocalDate, Customer] { case row =>
         Customer(row._1, row._2, row._3, row._4)
}
```
New way 
```
query.to {
  case row => Customer(row._1, row._2, row._3, row._4)
}
```
Or we can just execute query, get the flat tuple and map ZStream to user defined data type.

3. I added ability to create "aspects". So far only one aspect is supported - "nullable" when describing a column.
```
import ColumnSetAspect._

val persons =
      (uuid("id") ++ string("name") ++ (localDate("dob") @@ nullable))
        .table("persons")

val (personId, name, dob) = persons.columns
```
`dob` is the Expr of type Option[LocalDate]. This forces user to deal with option when executing a query and mapping returned row. 
However I am not sure how useful this is as everything in sql can actually be nullable -> e.g. even columns marked with Not Null constrain, can be null if queried with outer join. And IMO it does not make sense to have all the types as Option, so users will have to deal with nullability in some cases by themselves . Thoughts?

4. Couple of bugs mostly regarding "group by" and "having" were fixed. Right now its no longer possible to write certain queries that would blow up in runtime, like :
```
select(Count(id) ++ customerId)
     .from(orders) 
     .having(Count(id) > 4)
```
That would blow up on database as customerId need to be grouped. This PR makes the above not to compile.

