### PR TITLE
Mapping of Schema types to corresponding SqlServer types for Insert case

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,9 @@
 name: CI
 
+env:
+  JDK_JAVA_OPTIONS: -XX:+PrintCommandLineFlags -XX:+UseG1GC -Xmx4g -Xms4g
+  JVM_OPTS: -XX:+PrintCommandLineFlags -XX:+UseG1GC -Xmx4g -Xms4g
+  
 on:
   pull_request:
   push:

--- a/sqlserver/src/main/scala/zio/sql/sqlserver/SqlServerRenderModule.scala
+++ b/sqlserver/src/main/scala/zio/sql/sqlserver/SqlServerRenderModule.scala
@@ -451,7 +451,7 @@ trait SqlServerRenderModule extends SqlServerSqlModule { self =>
                   render(value)
                 case StandardType.InstantType(formatter)       =>
                   render(s"'${formatter.format(value.asInstanceOf[Instant])}'")
-                case CharType                                  => render(s"'${value}'")
+                case CharType                                  => render(s"N'${value}'")
                 case IntType                                   => render(value)
                 case StandardType.MonthDayType                 => render(s"'${value}'")
                 case BinaryType                                =>
@@ -480,7 +480,7 @@ trait SqlServerRenderModule extends SqlServerSqlModule { self =>
                 case StandardType.OffsetTimeType(_)            =>
                   render(s"'${fmtTimeOffset.format(value.asInstanceOf[OffsetTime])}'")
                 case LongType                                  => render(value)
-                case StringType                                => render(s"'${value}'")
+                case StringType                                => render(s"N'${value}'")
                 case StandardType.PeriodType                   => render(s"'${value}'")
                 case StandardType.ZoneIdType                   => render(s"'${value}'")
                 case StandardType.LocalDateType(_)             =>

--- a/sqlserver/src/main/scala/zio/sql/sqlserver/SqlServerRenderModule.scala
+++ b/sqlserver/src/main/scala/zio/sql/sqlserver/SqlServerRenderModule.scala
@@ -471,7 +471,7 @@ trait SqlServerRenderModule extends SqlServerSqlModule { self =>
                   render(s"'${fmtDateTimeOffset.format(value.asInstanceOf[OffsetDateTime])}'")
                 case StandardType.ZonedDateTimeType(_)         =>
                   render(s"'${fmtDateTimeOffset.format(value.asInstanceOf[ZonedDateTime])}'")
-                case BigIntegerType                            => render(s"'${value}'")
+                case BigIntegerType                            => render(value)
                 case UUIDType                                  => render(s"'${value}'")
                 case StandardType.ZoneOffsetType               => render(s"'${value}'")
                 case ShortType                                 => render(value)

--- a/sqlserver/src/main/scala/zio/sql/sqlserver/SqlServerSqlModule.scala
+++ b/sqlserver/src/main/scala/zio/sql/sqlserver/SqlServerSqlModule.scala
@@ -3,7 +3,7 @@ package zio.sql.sqlserver
 import zio.schema.Schema
 import zio.sql.Sql
 
-import java.time.LocalDate
+import java.time.{ Instant, LocalDate, LocalDateTime, LocalTime, OffsetDateTime, OffsetTime, ZonedDateTime }
 import java.time.format.DateTimeFormatter
 
 trait SqlServerSqlModule extends Sql { self =>
@@ -96,4 +96,21 @@ trait SqlServerSqlModule extends Sql { self =>
   implicit val localDateSchema =
     Schema.primitive[LocalDate](zio.schema.StandardType.LocalDateType(DateTimeFormatter.ISO_LOCAL_DATE))
 
+  implicit val instantSchema =
+    Schema.primitive[Instant](zio.schema.StandardType.InstantType(DateTimeFormatter.ISO_OFFSET_DATE_TIME))
+
+  implicit val localTimeSchema =
+    Schema.primitive[LocalTime](zio.schema.StandardType.LocalTimeType(DateTimeFormatter.ISO_LOCAL_TIME))
+
+  implicit val localDateTimeSchema =
+    Schema.primitive[LocalDateTime](zio.schema.StandardType.LocalDateTimeType(DateTimeFormatter.ISO_LOCAL_DATE_TIME))
+
+  implicit val offsetTimeSchema =
+    Schema.primitive[OffsetTime](zio.schema.StandardType.OffsetTimeType(DateTimeFormatter.ISO_OFFSET_TIME))
+
+  implicit val offsetDateTimeSchema =
+    Schema.primitive[OffsetDateTime](zio.schema.StandardType.OffsetDateTimeType(DateTimeFormatter.ISO_OFFSET_DATE_TIME))
+
+  implicit val zonedDatetimeSchema =
+    Schema.primitive[ZonedDateTime](zio.schema.StandardType.ZonedDateTimeType(DateTimeFormatter.ISO_ZONED_DATE_TIME))
 }

--- a/sqlserver/src/test/resources/db_schema.sql
+++ b/sqlserver/src/test/resources/db_schema.sql
@@ -37,6 +37,28 @@ create table order_details
     unit_price money not null
 );
 
+create table all_types(
+    id varchar(36) not null primary key,
+    bytearray varbinary(100) not null,
+    bigdecimal decimal(28) not null,
+    boolean_ bit not null,
+    char_ varchar(4) not null,
+    double_ float not null,
+    float_ real not null,
+    instant datetimeoffset not null,
+    int_ int not null,
+    optional_int int,
+    localdate date not null,
+    localdatetime datetime2(4) not null,
+    localtime time not null,
+    long_ bigint not null,
+    offsetdatetime datetimeoffset(4) not null,
+    offsettime datetimeoffset not null,
+    short smallint not null,
+    string varchar(max) not null,
+    uuid varchar(36) not null,
+    zoneddatetime datetimeoffset not null
+);
 
 insert into customers
     (id, first_name, last_name, verified, dob)

--- a/sqlserver/src/test/resources/db_schema.sql
+++ b/sqlserver/src/test/resources/db_schema.sql
@@ -42,22 +42,24 @@ create table all_types(
     bytearray varbinary(100) not null,
     bigdecimal decimal(28) not null,
     boolean_ bit not null,
-    char_ varchar(4) not null,
+    char_ char(1) not null,
     double_ float not null,
     float_ real not null,
     instant datetimeoffset not null,
     int_ int not null,
     optional_int int,
     localdate date not null,
-    localdatetime datetime2(4) not null,
+    localdatetime datetime2 not null,
     localtime time not null,
     long_ bigint not null,
-    offsetdatetime datetimeoffset(4) not null,
+    offsetdatetime datetimeoffset not null,
     offsettime datetimeoffset not null,
     short smallint not null,
     string varchar(max) not null,
     uuid varchar(36) not null,
-    zoneddatetime datetimeoffset not null
+    zoneddatetime datetimeoffset not null,
+    nchar_ nchar(1) not null,
+    nvarchar_ nvarchar(30) not null
 );
 
 insert into customers

--- a/sqlserver/src/test/scala/zio/sql/sqlserver/DbSchema.scala
+++ b/sqlserver/src/test/scala/zio/sql/sqlserver/DbSchema.scala
@@ -62,7 +62,9 @@ trait DbSchema extends Jdbc { self =>
         short("short") ++
         string("string") ++
         uuid("uuid") ++
-        zonedDateTime("zoneddatetime")).table("all_types")
+        zonedDateTime("zoneddatetime") ++
+        char("nchar_") ++
+        string("nvarchar_")).table("all_types")
 
     val (
       id,
@@ -84,7 +86,9 @@ trait DbSchema extends Jdbc { self =>
       shortCol,
       stringCol,
       uuidCol,
-      zonedDatetimeCol
+      zonedDatetimeCol,
+      ncharCol,
+      nvarcharCol
     ) = allTypes.columns
   }
 }

--- a/sqlserver/src/test/scala/zio/sql/sqlserver/DbSchema.scala
+++ b/sqlserver/src/test/scala/zio/sql/sqlserver/DbSchema.scala
@@ -41,5 +41,50 @@ trait DbSchema extends Jdbc { self =>
       .asTable("derived")
 
     val orderDateDerived = orderDateDerivedTable.columns
+
+    val allTypes =
+      (uuid("id") ++
+        byteArray("bytearray") ++
+        bigDecimal("bigdecimal") ++
+        boolean("boolean_") ++
+        char("char_") ++
+        double("double_") ++
+        float("float_") ++
+        instant("instant") ++
+        int("int_") ++
+        (int("optional_int") @@ ColumnSetAspect.nullable) ++
+        localDate("localdate") ++
+        localDateTime("localdatetime") ++
+        localTime("localtime") ++
+        long("long_") ++
+        offsetDateTime("offsetdatetime") ++
+        offsetTime("offsettime") ++
+        short("short") ++
+        string("string") ++
+        uuid("uuid") ++
+        zonedDateTime("zoneddatetime")).table("all_types")
+
+    val (
+      id,
+      bytearrayCol,
+      bigdecimalCol,
+      booleanCol,
+      charCol,
+      doubleCol,
+      floatCol,
+      instantCol,
+      intCol,
+      optionalIntCol,
+      localdateCol,
+      localdatetimeCol,
+      localtimeCol,
+      longCol,
+      offsetdatetimeCol,
+      offsettimeCol,
+      shortCol,
+      stringCol,
+      uuidCol,
+      zonedDatetimeCol
+    ) = allTypes.columns
   }
 }

--- a/sqlserver/src/test/scala/zio/sql/sqlserver/SqlServerModuleSpec.scala
+++ b/sqlserver/src/test/scala/zio/sql/sqlserver/SqlServerModuleSpec.scala
@@ -1,7 +1,6 @@
 package zio.sql.sqlserver
 
 import zio._
-import zio.prelude._
 import zio.schema._
 import zio.test.Assertion._
 import zio.test.TestAspect.{ retries, samples, sequential, shrinks }
@@ -9,6 +8,7 @@ import zio.test._
 
 import java.time._
 import java.time.format.DateTimeFormatter
+import java.time.temporal.ChronoUnit
 import java.util.UUID
 import scala.language.postfixOps
 
@@ -601,6 +601,9 @@ object SqlServerModuleSpec extends SqlServerRunnableSpec with DbSchema {
       assertZIO(execute(command))(equalTo(2))
     },
     test("Can insert all supported types") {
+      import AllTypesHelper._
+      import zio.prelude._
+
       val sqlMinDateTime = LocalDateTime.of(1, 1, 1, 0, 0)
       val sqlMaxDateTime = LocalDateTime.of(9999, 12, 31, 23, 59)
 
@@ -645,7 +648,7 @@ object SqlServerModuleSpec extends SqlServerRunnableSpec with DbSchema {
         Gen.chunkOfBounded(1, 100)(Gen.byte),
         Gen.bigDecimal(Long.MinValue, Long.MaxValue),
         Gen.boolean,
-        Gen.char,
+        Gen.asciiChar,
         Gen.double,
         Gen.float,
         sqlInstant,
@@ -658,39 +661,162 @@ object SqlServerModuleSpec extends SqlServerRunnableSpec with DbSchema {
         sqlOffsetDateTime,
         sqlOffsetTime,
         Gen.short,
-        Gen.string,
+        Gen.stringBounded(2, 30)(Gen.asciiChar),
         Gen.uuid,
-        sqlZonedDateTime
+        sqlZonedDateTime,
+        Gen.char,
+        Gen.stringBounded(2, 30)(Gen.char)
       ).tupleN
+
+      case class RowDates(
+        localDate: LocalDate,
+        localDateTime: LocalDateTime,
+        localTime: LocalTime,
+        offsetDateTime: Instant,
+        offsetTime: OffsetTime,
+        zonedDateTime: Instant
+      )
+      case class RowBasic(
+        id: UUID,
+        bigDecimal: BigDecimal,
+        boolean: Boolean,
+        char: Char,
+        double: Double,
+        float: Float,
+        int: Int,
+        long: Long,
+        short: Short,
+        string: String,
+        nchar: Char,
+        nvarchar: String,
+        bytearray: Chunk[Byte]
+      )
 
       check(gen) { row =>
         val insert = insertInto(allTypes)(
-          id,
+          id,            // 1
           bytearrayCol,
+          bigdecimalCol, // 3
+          booleanCol,    // 4
+          charCol,       // 5
+          doubleCol,     // 6
+          floatCol,      // 7
+          instantCol,
+          intCol,        // 9
+          optionalIntCol,
+          localdateCol,  // 11
+          localdatetimeCol,
+          localtimeCol,
+          longCol,       // 14
+          offsetdatetimeCol,
+          offsettimeCol,
+          shortCol,      // 17
+          stringCol,     // 18
+          uuidCol,
+          zonedDatetimeCol,
+          ncharCol,      // 21
+          nvarcharCol    // 22
+        ).values(row)
+
+        val query = select(
+          id,
           bigdecimalCol,
           booleanCol,
           charCol,
           doubleCol,
           floatCol,
-          instantCol,
           intCol,
-          optionalIntCol,
-          localdateCol,
-          localdatetimeCol,
-          localtimeCol,
           longCol,
-          offsetdatetimeCol,
-          offsettimeCol,
           shortCol,
           stringCol,
-          uuidCol,
-          zonedDatetimeCol
-        ).values(row)
+          ncharCol,
+          nvarcharCol,
+          bytearrayCol
+        )
+          .from(allTypes)
+          .where(id === row._1)
 
-        assertZIO(execute(insert))(equalTo(1))
+        val expectedBasic = RowBasic(
+          row._1,
+          row._3,
+          row._4,
+          row._5,
+          row._6,
+          row._7,
+          row._9,
+          row._14,
+          row._17,
+          row._18,
+          row._21,
+          row._22,
+          row._2
+        )
+        val assertionB    = for {
+          _   <- execute(insert)
+          rb  <- execute(query).runHead.some
+          rowB = RowBasic(rb._1, rb._2, rb._3, rb._4, rb._5, rb._6, rb._7, rb._8, rb._9, rb._10, rb._11, rb._12, rb._13)
+        } yield assert(rowB) {
+          val assertB = assertM(expectedBasic) _
+          assertB("UUID")(_.id) &&
+          assertB("BigDecimal")(_.bigDecimal) &&
+          assertB("Boolean")(_.boolean) &&
+          assertB("Char")(_.char) &&
+          assertB("Double")(_.double) &&
+          assertB("Float")(_.float) &&
+          assertB("Int")(_.int) &&
+          assertB("Long")(_.long) &&
+          assertB("Short")(_.short) &&
+          assertB("String")(_.string) &&
+          assertB("Unicode char")(_.nchar) &&
+          assertB("Unicode string")(_.nvarchar) &&
+          assertB("Chunk[Byte]")(_.bytearray)
+        }
+        assertionB.mapErrorCause(cause => Cause.stackless(cause.untraced))
+
+        val queryDates =
+          select(localdateCol, localdatetimeCol, localtimeCol, offsetdatetimeCol, offsettimeCol, zonedDatetimeCol)
+            .from(allTypes)
+            .where(id === row._1)
+
+        val expectedDates =
+          RowDates(row._11, normLdt(row._12), normLt(row._13), normOdt(row._15), normOt(row._16), normZdt(row._20))
+        val assertionD    = for {
+          _   <- execute(insert)
+          rd  <- execute(queryDates).runHead.some
+          rowD = RowDates(rd._1, normLdt(rd._2), normLt(rd._3), normOdt(rd._4), normOt(rd._5), normZdt(rd._6))
+        } yield assert(rowD) {
+          val assertD = assertM(expectedDates) _
+          assertD("LocalTime")(_.localTime) &&
+          assertD("LocalDate")(_.localDate) &&
+          assertD("LocalDateTime")(_.localDateTime) &&
+          //              assertD("OffsetDateTime")(_.offsetDateTime) &&
+          //              assertD("OffsetTime")(_.offsetTime) &&
+          assertD("zonedDateTime")(_.zonedDateTime)
+        }
+        assertionD.mapErrorCause(cause => Cause.stackless(cause.untraced))
       }
     } @@ samples(1) @@ retries(0) @@ shrinks(0)
   ) @@ sequential
+
+  private object AllTypesHelper {
+    def normLt(in: LocalTime): LocalTime =
+      in.truncatedTo(ChronoUnit.MICROS)
+
+    def normLdt(in: LocalDateTime): LocalDateTime =
+      LocalDateTime.of(in.toLocalDate, normLt(in.toLocalTime))
+
+    def normOt(in: OffsetTime): OffsetTime =
+      OffsetTime.of(normLt(in.toLocalTime), in.getOffset)
+
+    def normOdt(in: OffsetDateTime): Instant =
+      OffsetDateTime.of(normLdt(in.toLocalDateTime), in.getOffset).toInstant
+
+    def normZdt(in: ZonedDateTime): Instant =
+      ZonedDateTime.of(normLdt(in.toLocalDateTime), in.getZone).toInstant
+
+    def assertM[B, T](expected: B)(name: String)(extract: B => T): Assertion[B] =
+      assertionRec[B, T](name)(equalTo(extract(expected)))(p => Option(extract(p)))
+  }
 
   case class CustomerAndDateRow(firstName: String, lastName: String, orderDate: LocalDate)
   private val crossOuterApplyExpected = Seq(


### PR DESCRIPTION
SqlServer limitations:
DATETIME2  ISO format: YYYY-MM-DDThh:mm:ss[.nnnnnnn] , precision 0 to 7 digits, with an accuracy of 100ns (default 7)
DATETIMEOFFSET ISO format: YYYY-MM-DDThh:mm:ss[.nnnnnnn][{+|-}hh:mm], precision 0 to 7 digits, with an accuracy of 100ns (default 7)
TIME format: hh:mm[:ss][.fractional seconds]  precision 0 to 7 digits, with an accuracy of 100ns (default 7)
DATETIME is not supported. ISO fromat: YYYY-MM-DDThh:mm:ss[.mmm], Rounded to increments of .000, .003, or .007 seconds. 
Duration is not available in MSSQL.
DECIMAL can be used as analog of BigDecimal. Maximum precision 38 digits (default 18). 