### PR TITLE
Remove sbt warnings and update Scala versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
       fail-fast: false
       matrix:
         java: ['adopt@1.8', 'adopt@1.11']
-        scala: ['2.12.16', '2.13.8']
+        scala: ['2.12.17', '2.13.10']
     steps:
       - name: Checkout current branch
         uses: actions/checkout@v2.3.4

--- a/build.sbt
+++ b/build.sbt
@@ -64,7 +64,7 @@ lazy val core = crossProject(JSPlatform, JVMPlatform)
       "dev.zio" %% "zio-test-sbt"          % zioVersion % Test
     ),
     dependencyOverrides += "dev.zio" %% "zio" % zioVersion,
-    resolvers += Resolver.sonatypeRepo("snapshots")
+    resolvers ++= Resolver.sonatypeOssRepos("snapshots")
   )
   .settings(testFrameworks += new TestFramework("zio.test.sbt.ZTestFramework"))
 
@@ -116,7 +116,7 @@ lazy val driver = project
       "dev.zio" %% "zio-test-sbt"          % zioVersion % Test
     ),
     dependencyOverrides += "dev.zio" %% "zio" % zioVersion,
-    resolvers += Resolver.sonatypeRepo("snapshots")
+    resolvers ++= Resolver.sonatypeOssRepos("snapshots")
   )
   .settings(testFrameworks += new TestFramework("zio.test.sbt.ZTestFramework"))
 

--- a/core/jvm/src/main/scala/zio/sql/features.scala
+++ b/core/jvm/src/main/scala/zio/sql/features.scala
@@ -2,6 +2,8 @@ package zio.sql
 
 import scala.annotation.implicitNotFound
 
+import com.github.ghik.silencer.silent
+
 trait FeaturesModule {
 
   type :||:[A, B] = Features.Union[A, B]
@@ -16,6 +18,8 @@ trait FeaturesModule {
 
     sealed trait IsNotAggregated[A]
     object IsNotAggregated {
+
+      @silent
       implicit def UnionIsNotAgregated[A: IsNotAggregated, B: IsNotAggregated]: IsNotAggregated[Union[A, B]] =
         new IsNotAggregated[Union[A, B]] {}
 
@@ -41,6 +45,7 @@ trait FeaturesModule {
 
       implicit val LiteralIsAggregated: IsFullyAggregated[Literal] = new IsFullyAggregated[Literal] {}
 
+      @silent
       implicit def UnionIsAggregated[A: IsFullyAggregated, B: IsFullyAggregated]: IsFullyAggregated[Union[A, B]] =
         new IsFullyAggregated[Union[A, B]] {}
     }

--- a/core/jvm/src/main/scala/zio/sql/select.scala
+++ b/core/jvm/src/main/scala/zio/sql/select.scala
@@ -1,5 +1,7 @@
 package zio.sql
 
+import com.github.ghik.silencer.silent
+
 import scala.language.implicitConversions
 
 trait SelectModule { self: ExprModule with TableModule with UtilsModule with GroupByUtilsModule =>
@@ -288,39 +290,47 @@ trait SelectModule { self: ExprModule with TableModule with UtilsModule with Gro
       ): Subselect[F, Repr, Source, Subsource, Head, Tail] =
         copy(havingExpr = self.havingExpr && havingExpr2)
 
-      // format: off          
+      // format: off
+      @silent
       def groupBy[F1: Features.IsNotAggregated](expr1: Expr[F1, Source, Any]): Subselect.WithGroupByF[F, Repr, Source, Subsource, Head, Tail, self.GroupByF with F1] =
         new Subselect(selection, table, whereExpr, self.groupByExprs ++ expr1, havingExpr, orderByExprs, offset, limit) {
          override type GroupByF = self.GroupByF with F1
        }
 
+      @silent
       def groupBy[F1: Features.IsNotAggregated, F2: Features.IsNotAggregated](expr1: Expr[F1, Source, Any], expr2: Expr[F2, Source, Any]): Subselect.WithGroupByF[F, Repr, Source, Subsource, Head, Tail, self.GroupByF with F1 with F2] =
         new Subselect(selection, table, whereExpr, self.groupByExprs ++ expr1 ++ expr2, havingExpr, orderByExprs, offset, limit) {
          override type GroupByF = self.GroupByF with  F1 with F2
       }
 
+      @silent
       def groupBy[F1: Features.IsNotAggregated, F2: Features.IsNotAggregated, F3: Features.IsNotAggregated](expr1: Expr[F1, Source, Any], expr2: Expr[F2, Source, Any], expr3: Expr[F3, Source, Any]): Subselect.WithGroupByF[F, Repr, Source, Subsource, Head, Tail, self.GroupByF with F1 with F2 with F3] =
         new Subselect(selection, table, whereExpr,self.groupByExprs ++ expr1 ++ expr2 ++ expr3, havingExpr, orderByExprs, offset, limit) {
          override type GroupByF =  self.GroupByF with F1 with F2 with F3
       }
 
+      @silent
       def groupBy[F1: Features.IsNotAggregated, F2: Features.IsNotAggregated, F3: Features.IsNotAggregated, F4: Features.IsNotAggregated](expr1: Expr[F1, Source, Any], expr2: Expr[F2, Source, Any], expr3: Expr[F3, Source, Any], expr4: Expr[F4, Source, Any]): Subselect.WithGroupByF[F, Repr, Source, Subsource, Head, Tail, self.GroupByF with F1 with F2 with F3 with F4] =
         new Subselect(selection, table, whereExpr, self.groupByExprs ++ expr1 ++ expr2 ++ expr3 ++ expr4, havingExpr, orderByExprs, offset, limit) {
          override type GroupByF = self.GroupByF with F1 with F2 with F3 with F4
       }
-
+      
+      @silent
       def groupBy[F1: Features.IsNotAggregated, F2: Features.IsNotAggregated, F3: Features.IsNotAggregated, F4: Features.IsNotAggregated, F5: Features.IsNotAggregated](expr1: Expr[F1, Source, Any], expr2: Expr[F2, Source, Any], expr3: Expr[F3, Source, Any], expr4: Expr[F4, Source, Any], expr5: Expr[F5, Source, Any]): Subselect.WithGroupByF[F, Repr, Source, Subsource, Head, Tail, self.GroupByF with F1 with F2 with F3 with F4 with F5] =
         new Subselect(selection, table, whereExpr, self.groupByExprs ++ expr1 ++ expr2 ++ expr3 ++ expr4 ++ expr5, havingExpr, orderByExprs, offset, limit) {
          override type GroupByF =  self.GroupByF with F1 with F2 with F3 with F4 with F5
       }
-
+      
+      @silent
       def groupBy[F1: Features.IsNotAggregated, F2: Features.IsNotAggregated, F3: Features.IsNotAggregated, F4: Features.IsNotAggregated, F5: Features.IsNotAggregated, F6: Features.IsNotAggregated](expr1: Expr[F1, Source, Any], expr2: Expr[F2, Source, Any], expr3: Expr[F3, Source, Any], expr4: Expr[F4, Source, Any], expr5: Expr[F5, Source, Any], expr6: Expr[F6, Source, Any]): Subselect.WithGroupByF[F, Repr, Source, Subsource, Head, Tail, self.GroupByF with F1 with F2 with F3 with F4 with F5 with F6] =
         new Subselect(selection, table, whereExpr, self.groupByExprs ++ expr1 ++ expr2 ++ expr3 ++ expr4 ++ expr5 ++ expr6, havingExpr, orderByExprs, offset, limit) {
          override type GroupByF =  self.GroupByF with F1 with F2 with F3 with F4 with F5 with F6
       }
+
       /**
         * TODO add arities up to 22 when needed / requested by users
         */
+      @silent
       def groupBy[F1: Features.IsNotAggregated, F2: Features.IsNotAggregated, F3: Features.IsNotAggregated, F4: Features.IsNotAggregated, F5: Features.IsNotAggregated, F6: Features.IsNotAggregated, F7: Features.IsNotAggregated](expr1: Expr[F1, Source, Any], expr2: Expr[F2, Source, Any], expr3: Expr[F3, Source, Any], expr4: Expr[F4, Source, Any], expr5: Expr[F5, Source, Any], expr6: Expr[F6, Source, Any], expr7: Expr[F7, Source, Any]): Subselect.WithGroupByF[F, Repr, Source, Subsource, Head, Tail, self.GroupByF with F1 with F2 with F3 with F4 with F5 with F6 with F7] =
         new Subselect(selection, table, whereExpr, self.groupByExprs ++ expr1 ++ expr2 ++ expr3 ++ expr4 ++ expr5 ++ expr6 ++ expr7, havingExpr, orderByExprs, offset, limit) {
          override type GroupByF =  self.GroupByF with F1 with F2 with F3 with F4 with F5 with F6 with F7

--- a/postgres/src/test/scala/zio/sql/postgresql/PostgresSqlModuleSpec.scala
+++ b/postgres/src/test/scala/zio/sql/postgresql/PostgresSqlModuleSpec.scala
@@ -1,22 +1,24 @@
 package zio.sql.postgresql
 
-import zio._
-import zio.test.Assertion._
-import zio.test.TestAspect._
-import zio.test._
-
+import java.math.BigDecimal
 import java.time._
 import java.util.UUID
-import scala.language.postfixOps
+
+import com.github.ghik.silencer.silent
+import zio._
 import zio.schema._
-import zio.schema.TypeId
-import java.math.BigDecimal
+import zio.test._
+import zio.test.Assertion._
+import zio.test.TestAspect._
+
+import scala.language.postfixOps
 
 object PostgresSqlModuleSpec extends PostgresRunnableSpec with DbSchema {
 
   import AggregationDef._
   import CustomerSchema._
 
+  @silent
   private def customerSelectJoseAssertion[F: Features.IsNotAggregated](
     condition: Expr[F, customers.TableType, Boolean]
   ) = {

--- a/project/BuildHelper.scala
+++ b/project/BuildHelper.scala
@@ -10,15 +10,14 @@ import scalafix.sbt.ScalafixPlugin.autoImport.scalafixSemanticdb
 
 object BuildHelper {
   val SilencerVersion = "1.7.12"
-  val Scala212        = "2.12.16"
-  val Scala213        = "2.13.8"
+  val Scala212        = "2.12.17"
+  val Scala213        = "2.13.10"
   val ScalaDotty      = "3.0.0-RC3"
 
   def buildInfoSettings(packageName: String) =
     Seq(
-      buildInfoKeys    := Seq[BuildInfoKey](name, version, scalaVersion, sbtVersion, isSnapshot),
-      buildInfoPackage := packageName,
-      buildInfoObject  := "BuildInfo"
+      buildInfoKeys    := Seq[BuildInfoKey](organization, moduleName, name, version, scalaVersion, sbtVersion, isSnapshot),
+      buildInfoPackage := packageName
     )
 
   private val stdOptions = Seq(
@@ -35,7 +34,7 @@ object BuildHelper {
     "-language:existentials",
     "-explaintypes",
     "-Yrangepos",
-    "-Xlint:_,-missing-interpolator,-type-parameter-shadow",
+    "-Xlint:_,-missing-interpolator,-type-parameter-shadow,-infer-any",
     "-Ywarn-numeric-widen",
     "-Ywarn-value-discard"
   )
@@ -53,10 +52,11 @@ object BuildHelper {
 
   def extraOptions(scalaVersion: String, optimize: Boolean) =
     CrossVersion.partialVersion(scalaVersion) match {
-      case Some((0, _))  =>
+      case Some((3, _))  =>
         Seq(
           "-language:implicitConversions",
-          "-Xignore-scala2-macros"
+          "-Xignore-scala2-macros",
+          "-noindent"
         )
       case Some((2, 13)) =>
         Seq(
@@ -71,7 +71,6 @@ object BuildHelper {
           "-Ypartial-unification",
           "-Yno-adapted-args",
           "-Ywarn-inaccessible",
-          "-Ywarn-infer-any",
           "-Ywarn-nullary-override",
           "-Ywarn-nullary-unit",
           "-Ywarn-unused:params,-implicits",
@@ -154,15 +153,15 @@ object BuildHelper {
     libraryDependencies ++= {
       if (scalaVersion.value == ScalaDotty)
         Seq(
-          "com.github.ghik"                 % s"silencer-lib_2.13.6" % SilencerVersion % Provided
+          "com.github.ghik"                 % s"silencer-lib_2.13.10" % SilencerVersion % Provided
         )
       else
         Seq(
-          ("com.github.ghik"                % "silencer-lib"         % SilencerVersion % Provided).cross(CrossVersion.full),
-          compilerPlugin(("com.github.ghik" % "silencer-plugin"      % SilencerVersion).cross(CrossVersion.full))
+          ("com.github.ghik"                % "silencer-lib"          % SilencerVersion % Provided).cross(CrossVersion.full),
+          compilerPlugin(("com.github.ghik" % "silencer-plugin"       % SilencerVersion).cross(CrossVersion.full))
         )
     },
-    resolvers += Resolver.sonatypeRepo("snapshots"),
+    resolvers ++= Resolver.sonatypeOssRepos("snapshots"),
     Test / parallelExecution := true,
     incOptions ~= (_.withLogRecompileOnMacro(false)),
     autoAPIMappings          := true,

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("org.scala-js"                      % "sbt-scalajs"               % "1.7.0")
+addSbtPlugin("org.scala-js"                      % "sbt-scalajs"               % "1.12.0")
 addSbtPlugin("org.portable-scala"                % "sbt-scalajs-crossproject"  % "1.2.0")
 addSbtPlugin("org.scalameta"                     % "sbt-scalafmt"              % "2.5.0")
 addSbtPlugin("pl.project13.scala"                % "sbt-jmh"                   % "0.4.3")
@@ -12,6 +12,6 @@ addSbtPlugin("com.github.cb372"                  % "sbt-explicit-dependencies" %
 addSbtPlugin("com.thoughtworks.sbt-api-mappings" % "sbt-api-mappings"          % "3.0.2")
 addSbtPlugin("ch.epfl.scala"                     % "sbt-scalafix"              % "0.10.1")
 addSbtPlugin("io.github.davidgregory084"         % "sbt-tpolecat"              % "0.4.1")
-addSbtPlugin("dev.zio"                           % "zio-sbt-website"           % "0.0.0+84-6fd7d64e-SNAPSHOT")
+addSbtPlugin("dev.zio"                           % "zio-sbt-website"           % "0.1.0")
 
-resolvers += Resolver.sonatypeRepo("public")
+resolvers ++= Resolver.sonatypeOssRepos("public")

--- a/sbt
+++ b/sbt
@@ -34,11 +34,11 @@
 
 set -o pipefail
 
-declare -r sbt_release_version="1.3.13"
+declare -r sbt_release_version="1.8.0"
 declare -r sbt_unreleased_version="1.4.0-M1"
 
-declare -r latest_213="2.13.6"
-declare -r latest_212="2.12.14"
+declare -r latest_213="2.13.10"
+declare -r latest_212="2.12.17"
 declare -r latest_211="2.11.12"
 declare -r latest_210="2.10.7"
 declare -r latest_29="2.9.3"

--- a/sqlserver/src/main/scala/zio/sql/sqlserver/SqlServerSqlModule.scala
+++ b/sqlserver/src/main/scala/zio/sql/sqlserver/SqlServerSqlModule.scala
@@ -1,7 +1,8 @@
 package zio.sql.sqlserver
 
-import zio.sql.Sql
 import java.math.BigDecimal
+
+import zio.sql.Sql
 
 trait SqlServerSqlModule extends Sql { self =>
 

--- a/sqlserver/src/test/scala/zio/sql/sqlserver/SqlServerModuleSpec.scala
+++ b/sqlserver/src/test/scala/zio/sql/sqlserver/SqlServerModuleSpec.scala
@@ -1,17 +1,18 @@
 package zio.sql.sqlserver
 
-import zio._
-import zio.test.Assertion._
-import zio.test.TestAspect.{ retries, samples, sequential, shrinks }
-import zio.test._
-
+import java.math.{ BigDecimal, RoundingMode }
 import java.time._
 import java.time.temporal.ChronoUnit
 import java.util.UUID
-import scala.language.postfixOps
-import zio.schema.DeriveSchema
 
-import java.math.{ BigDecimal, RoundingMode }
+import com.github.ghik.silencer.silent
+import zio._
+import zio.schema.DeriveSchema
+import zio.test._
+import zio.test.Assertion._
+import zio.test.TestAspect.{ retries, samples, sequential, shrinks }
+
+import scala.language.postfixOps
 
 object SqlServerModuleSpec extends SqlServerRunnableSpec {
 
@@ -28,6 +29,7 @@ object SqlServerModuleSpec extends SqlServerRunnableSpec {
 
   implicit val customerRow = DeriveSchema.gen[CustomerRow]
 
+  @silent
   private def customerSelectJoseAssertion[F: Features.IsNotAggregated](
     condition: Expr[F, customers.TableType, Boolean]
   ) = {


### PR DESCRIPTION
- update Scala versions for 2.12 and 2.13
- @silence invalid warnings introduced by Scala >= 2.13.9
- set compiler options in line with the core ZIO project