### PR TITLE
Fix 0.1.0 release

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -75,6 +75,7 @@ lazy val coreJVM = core.jvm.dependsOn(macros)
 
 lazy val macros = project
   .in(file("macros"))
+  .settings(stdSettings("zio-sql-macros"))
   .settings(
     libraryDependencies ++= Seq(
       "org.scala-lang" % "scala-reflect" % scalaVersion.value,

--- a/macros/src/main/scala/zio/sql/macros/tablelike.scala
+++ b/macros/src/main/scala/zio/sql/macros/tablelike.scala
@@ -8,6 +8,7 @@ import zio.Chunk
 sealed trait TableSchema[T]
 
 object TableSchema {
+  import scala.language.experimental.macros
 
   final case class Compatible[T]() extends TableSchema[T]
 


### PR DESCRIPTION
This fixes the problem with publish phase failing in v0.1.0 release because zio-sql-macros_2.12 module was missing.