### PR TITLE
Hardcode MySQL version

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -26,7 +26,7 @@ addCommandAlias("check", "all scalafmtSbtCheck scalafmtCheck test:scalafmtCheck"
 val zioVersion                 = "2.0.15"
 val zioSchemaVersion           = "0.4.13"
 val testcontainersVersion      = "1.18.3"
-val testcontainersScalaVersion = "0.40.17"
+val testcontainersScalaVersion = "0.41.3"
 val logbackVersion             = "1.3.8"
 
 lazy val root = project

--- a/jdbc-hikaricp/src/test/scala/zio/sql/MySqlTestContainer.scala
+++ b/jdbc-hikaricp/src/test/scala/zio/sql/MySqlTestContainer.scala
@@ -7,7 +7,7 @@ import zio._
 final case class MySqlConfig(username: String, password: String, url: String)
 object MySqlTestContainer {
 
-  def mysql(imageName: String = "mysql"): ZIO[Scope, Throwable, MySQLContainer] =
+  def mysql(imageName: String = "mysql:8.2.0"): ZIO[Scope, Throwable, MySQLContainer] =
     ZIO.acquireRelease {
       ZIO.attemptBlocking {
         val c = new MySQLContainer(

--- a/mysql/src/test/scala/zio/sql/mysql/MysqlRunnableSpec.scala
+++ b/mysql/src/test/scala/zio/sql/mysql/MysqlRunnableSpec.scala
@@ -8,7 +8,7 @@ trait MysqlRunnableSpec extends JdbcRunnableSpec with MysqlJdbcModule {
 
   override protected def getContainer: SingleContainer[_] with JdbcDatabaseContainer =
     new MySQLContainer(
-      mysqlImageVersion = Option("mysql").map(DockerImageName.parse)
+      mysqlImageVersion = Option("mysql:8.2.0").map(DockerImageName.parse)
     ).configure { a =>
       a.withInitScript("shop_schema.sql")
       ()


### PR DESCRIPTION
Latest MySQL removed `--skip-host-cache` flag but testcontainers still try to use it causing:
```
2024-03-29T15:45:29.779392Z 0 [ERROR] [MY-000068] [Server] unknown option '--skip-host-cache'.
2024-03-29T15:45:29.779894Z 0 [ERROR] [MY-013236] [Server] The designated data directory /var/lib/mysql/ is unusable. You can remove all files that the server added to it.
2024-03-29T15:45:29.779907Z 0 [ERROR] [MY-010119] [Server] Aborting
```
I've hardcoded the last MySQL version that has this flag.